### PR TITLE
Remove profiles from generated structs

### DIFF
--- a/ocsf/v1_4_0/account_change.go
+++ b/ocsf/v1_4_0/account_change.go
@@ -10,11 +10,29 @@ import (
 
 type AccountChange struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
+
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® Details: An array of <a target='_blank' href='https://attack.mitre.org'>MITRE ATT&CK®</a> objects describing identified tactics, techniques & sub-techniques.
+	Attacks []MITREATTCK `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Identity & Access Management</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -28,11 +46,26 @@ type AccountChange struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
+
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -43,11 +76,20 @@ type AccountChange struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
 	// HTTP Request: Details about the underlying HTTP request.
 	HttpRequest *HTTPRequest `json:"http_request,omitempty" parquet:"http_request,optional"`
 
 	// HTTP Response: Details about the underlying HTTP response.
 	HttpResponse *HTTPResponse `json:"http_response,omitempty" parquet:"http_response,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
 
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
@@ -58,14 +100,23 @@ type AccountChange struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
-
 	// Policies: Details about the IAM policies associated with the Attach/Detach Policy activities.
 	Policies []Policy `json:"policies,omitempty" parquet:"policies,list,optional"`
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the severity_id value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -137,25 +188,42 @@ func (v *AccountChange) ValidateObservables() error {
 }
 
 var AccountChangeFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
 	{Name: "http_request", Type: HTTPRequestStruct, Nullable: true},
 	{Name: "http_response", Type: HTTPResponseStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
 	{Name: "policies", Type: arrow.ListOf(PolicyStruct), Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "src_endpoint", Type: NetworkEndpointStruct, Nullable: true},

--- a/ocsf/v1_4_0/admin_group_query.go
+++ b/ocsf/v1_4_0/admin_group_query.go
@@ -10,11 +10,29 @@ import (
 
 type AdminGroupQuery struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
+
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® Details: An array of <a target='_blank' href='https://attack.mitre.org'>MITRE ATT&CK®</a> objects describing identified tactics, techniques & sub-techniques.
+	Attacks []MITREATTCK `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Discovery</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -28,11 +46,26 @@ type AdminGroupQuery struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
+
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -43,8 +76,17 @@ type AdminGroupQuery struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
 	// Group: The administrative group.
 	Group Group `json:"group" parquet:"group"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
 
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
@@ -55,8 +97,8 @@ type AdminGroupQuery struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Query Info: The search details associated with the query request.
 	QueryInfo *QueryInformation `json:"query_info,omitempty" parquet:"query_info,optional"`
@@ -69,6 +111,18 @@ type AdminGroupQuery struct {
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the severity_id value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -134,26 +188,44 @@ func (v *AdminGroupQuery) ValidateObservables() error {
 }
 
 var AdminGroupQueryFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
 	{Name: "group", Type: GroupStruct, Nullable: false},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "query_info", Type: QueryInformationStruct, Nullable: true},
 	{Name: "query_result", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "query_result_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "start_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},

--- a/ocsf/v1_4_0/airborne_broadcast_activity.go
+++ b/ocsf/v1_4_0/airborne_broadcast_activity.go
@@ -10,14 +10,32 @@ import (
 
 type AirborneBroadcastActivity struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
 
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
 	// Aircraft: The Aircraft object represents any aircraft or otherwise airborne asset such as an unmanned system, airplane, balloon, spacecraft, or otherwise. The Aircraft object is intended to normalized data captured or otherwise logged from active radar, passive radar, multi-spectral systems, or the Automatic Dependant Broadcast - Surveillance (ADS-B), and/or Mode S systems.
 	Aircraft *Aircraft `json:"aircraft,omitempty" parquet:"aircraft,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® Details: An array of <a target='_blank' href='https://attack.mitre.org'>MITRE ATT&CK®</a> objects describing identified tactics, techniques & sub-techniques.
+	Attacks []MITREATTCK `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Unmanned Systems</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -31,14 +49,29 @@ type AirborneBroadcastActivity struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Connection Info: The network connection information.
 	ConnectionInfo *NetworkConnectionInformation `json:"connection_info,omitempty" parquet:"connection_info,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
+
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Destination Endpoint: The destination network endpoint for the ADS-B system, if telemetry is being remotely broadcasted.
 	DstEndpoint *NetworkEndpoint `json:"dst_endpoint,omitempty" parquet:"dst_endpoint,optional"`
@@ -52,6 +85,15 @@ type AirborneBroadcastActivity struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
 
@@ -61,8 +103,8 @@ type AirborneBroadcastActivity struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// ADS-B Protocol: The specific protocol associated with the ADS-B system. E.g. <code>ADS-B UAT</code> or <code>ADS-B ES</code>.
 	ProtocolName *string `json:"protocol_name,omitempty" parquet:"protocol_name,optional"`
@@ -72,6 +114,18 @@ type AirborneBroadcastActivity struct {
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// RSSI: Recent average RSSI (signal power) measured in dbFS. This value will always be negative, e.g., <code>-87.13</code>.
 	Rssi *int32 `json:"rssi,omitempty" parquet:"rssi,optional"`
@@ -155,27 +209,45 @@ func (v *AirborneBroadcastActivity) ValidateObservables() error {
 }
 
 var AirborneBroadcastActivityFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
 	{Name: "aircraft", Type: AircraftStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "connection_info", Type: NetworkConnectionInformationStruct, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "dst_endpoint", Type: NetworkEndpointStruct, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "protocol_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "proxy_endpoint", Type: NetworkProxyEndpointStruct, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "rssi", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},

--- a/ocsf/v1_4_0/api_activity.go
+++ b/ocsf/v1_4_0/api_activity.go
@@ -10,6 +10,12 @@ import (
 
 type APIActivity struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
@@ -21,6 +27,12 @@ type APIActivity struct {
 
 	// API Details: Describes details about a typical API (Application Programming Interface) call.
 	Api API `json:"api" parquet:"api"`
+
+	// MITRE ATT&CK® Details: An array of <a target='_blank' href='https://attack.mitre.org'>MITRE ATT&CK®</a> objects describing identified tactics, techniques & sub-techniques.
+	Attacks []MITREATTCK `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Application Activity</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -34,11 +46,26 @@ type APIActivity struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
+
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Destination Endpoint: The network destination endpoint.
 	DstEndpoint *NetworkEndpoint `json:"dst_endpoint,omitempty" parquet:"dst_endpoint,optional"`
@@ -52,11 +79,20 @@ type APIActivity struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
 	// HTTP Request: Details about the underlying http request.
 	HttpRequest *HTTPRequest `json:"http_request,omitempty" parquet:"http_request,optional"`
 
 	// HTTP Response: Details about the underlying http response.
 	HttpResponse *HTTPResponse `json:"http_response,omitempty" parquet:"http_response,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
 
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
@@ -67,14 +103,26 @@ type APIActivity struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
 
 	// Resources Array: Details about resources that were affected by the activity/event.
 	Resources []ResourceDetails `json:"resources,omitempty" parquet:"resources,list,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the severity_id value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -140,28 +188,44 @@ func (v *APIActivity) ValidateObservables() error {
 }
 
 var APIActivityFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "actor", Type: ActorStruct, Nullable: false},
 	{Name: "api", Type: APIStruct, Nullable: false},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "dst_endpoint", Type: NetworkEndpointStruct, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
 	{Name: "http_request", Type: HTTPRequestStruct, Nullable: true},
 	{Name: "http_response", Type: HTTPResponseStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "resources", Type: arrow.ListOf(ResourceDetailsStruct), Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "src_endpoint", Type: NetworkEndpointStruct, Nullable: false},

--- a/ocsf/v1_4_0/application_error.go
+++ b/ocsf/v1_4_0/application_error.go
@@ -10,11 +10,29 @@ import (
 
 type ApplicationError struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
+
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® Details: An array of <a target='_blank' href='https://attack.mitre.org'>MITRE ATT&CK®</a> objects describing identified tactics, techniques & sub-techniques.
+	Attacks []MITREATTCK `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Application Activity</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -28,11 +46,26 @@ type ApplicationError struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
+
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -43,6 +76,15 @@ type ApplicationError struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
 	// Message: The error message as reported by the application.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
 
@@ -52,11 +94,23 @@ type ApplicationError struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the severity_id value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -119,22 +173,40 @@ func (v *ApplicationError) ValidateObservables() error {
 }
 
 var ApplicationErrorFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "start_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},

--- a/ocsf/v1_4_0/application_lifecycle.go
+++ b/ocsf/v1_4_0/application_lifecycle.go
@@ -10,14 +10,32 @@ import (
 
 type ApplicationLifecycle struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
 
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
 	// Application: The application that was affected by the lifecycle event.  This also applies to self-updating application systems.
 	App Product `json:"app" parquet:"app"`
+
+	// MITRE ATT&CK® Details: An array of <a target='_blank' href='https://attack.mitre.org'>MITRE ATT&CK®</a> objects describing identified tactics, techniques & sub-techniques.
+	Attacks []MITREATTCK `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Application Activity</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -31,11 +49,26 @@ type ApplicationLifecycle struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
+
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -46,6 +79,15 @@ type ApplicationLifecycle struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
 
@@ -55,11 +97,23 @@ type ApplicationLifecycle struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the severity_id value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -122,23 +176,41 @@ func (v *ApplicationLifecycle) ValidateObservables() error {
 }
 
 var ApplicationLifecycleFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
 	{Name: "app", Type: ProductStruct, Nullable: false},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "start_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},

--- a/ocsf/v1_4_0/authentication.go
+++ b/ocsf/v1_4_0/authentication.go
@@ -10,11 +10,26 @@ import (
 
 type Authentication struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
+
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® Details: An array of <a target='_blank' href='https://attack.mitre.org'>MITRE ATT&CK®</a> objects describing identified tactics, techniques & sub-techniques.
+	Attacks []MITREATTCK `json:"attacks,omitempty" parquet:"attacks,list,optional"`
 
 	// Authentication Factors: Describes a category of methods used for identity verification in an authentication attempt.
 	AuthFactors []AuthenticationFactor `json:"auth_factors,omitempty" parquet:"auth_factors,list,optional"`
@@ -24,6 +39,9 @@ type Authentication struct {
 
 	// Auth Protocol ID: The normalized identifier of the authentication protocol used to create the user session.
 	AuthProtocolId *int32 `json:"auth_protocol_id,omitempty" parquet:"auth_protocol_id,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Identity & Access Management</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -40,11 +58,26 @@ type Authentication struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
+
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Destination Endpoint: The endpoint to which the authentication was targeted.
 	DstEndpoint *NetworkEndpoint `json:"dst_endpoint,omitempty" parquet:"dst_endpoint,optional"`
@@ -58,11 +91,17 @@ type Authentication struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
 	// HTTP Request: Details about the underlying HTTP request.
 	HttpRequest *HTTPRequest `json:"http_request,omitempty" parquet:"http_request,optional"`
 
 	// HTTP Response: Details about the underlying HTTP response.
 	HttpResponse *HTTPResponse `json:"http_response,omitempty" parquet:"http_response,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
 
 	// Cleartext Credentials: Indicates whether the credentials were passed in clear text.<p><b>Note:</b> True if the credentials were passed in a clear text protocol such as FTP or TELNET, or if Windows detected that a user's logon password was passed to the authentication package in clear text.</p>
 	IsCleartext *bool `json:"is_cleartext,omitempty" parquet:"is_cleartext,optional"`
@@ -85,6 +124,9 @@ type Authentication struct {
 	// Logon Type ID: The normalized logon type identifier.
 	LogonTypeId *int32 `json:"logon_type_id,omitempty" parquet:"logon_type_id,optional"`
 
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
 
@@ -94,11 +136,23 @@ type Authentication struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Service: The service or gateway to which the user or process is being authenticated
 	Service *Service `json:"service,omitempty" parquet:"service,optional"`
@@ -173,24 +227,37 @@ func (v *Authentication) ValidateObservables() error {
 }
 
 var AuthenticationFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKStruct), Nullable: true},
 	{Name: "auth_factors", Type: arrow.ListOf(AuthenticationFactorStruct), Nullable: true},
 	{Name: "auth_protocol", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "auth_protocol_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "certificate", Type: DigitalCertificateStruct, Nullable: true},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "dst_endpoint", Type: NetworkEndpointStruct, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
 	{Name: "http_request", Type: HTTPRequestStruct, Nullable: true},
 	{Name: "http_response", Type: HTTPResponseStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
 	{Name: "is_cleartext", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
 	{Name: "is_mfa", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
 	{Name: "is_new_logon", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
@@ -198,11 +265,16 @@ var AuthenticationFields = []arrow.Field{
 	{Name: "logon_process", Type: ProcessStruct, Nullable: true},
 	{Name: "logon_type", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "logon_type_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "service", Type: ServiceStruct, Nullable: true},
 	{Name: "session", Type: SessionStruct, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},

--- a/ocsf/v1_4_0/authorize_session.go
+++ b/ocsf/v1_4_0/authorize_session.go
@@ -10,11 +10,29 @@ import (
 
 type AuthorizeSession struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
+
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® Details: An array of <a target='_blank' href='https://attack.mitre.org'>MITRE ATT&CK®</a> objects describing identified tactics, techniques & sub-techniques.
+	Attacks []MITREATTCK `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Identity & Access Management</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -28,11 +46,26 @@ type AuthorizeSession struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
+
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Destination Endpoint: The Endpoint for which the user session was targeted.
 	DstEndpoint *NetworkEndpoint `json:"dst_endpoint,omitempty" parquet:"dst_endpoint,optional"`
@@ -46,6 +79,9 @@ type AuthorizeSession struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
 	// Group: Group that was assigned to the new user session.
 	Group *Group `json:"group,omitempty" parquet:"group,optional"`
 
@@ -54,6 +90,12 @@ type AuthorizeSession struct {
 
 	// HTTP Response: Details about the underlying HTTP response.
 	HttpResponse *HTTPResponse `json:"http_response,omitempty" parquet:"http_response,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
 
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
@@ -64,14 +106,26 @@ type AuthorizeSession struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Privileges: The list of sensitive privileges, assigned to the new user session.
 	Privileges []string `json:"privileges,omitempty" parquet:"privileges,list,optional"`
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Session: The user session with the assigned privileges.
 	Session *Session `json:"session,omitempty" parquet:"session,optional"`
@@ -143,27 +197,45 @@ func (v *AuthorizeSession) ValidateObservables() error {
 }
 
 var AuthorizeSessionFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "dst_endpoint", Type: NetworkEndpointStruct, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
 	{Name: "group", Type: GroupStruct, Nullable: true},
 	{Name: "http_request", Type: HTTPRequestStruct, Nullable: true},
 	{Name: "http_response", Type: HTTPResponseStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "privileges", Type: arrow.ListOf(arrow.BinaryTypes.String), Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "session", Type: SessionStruct, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},

--- a/ocsf/v1_4_0/base_event.go
+++ b/ocsf/v1_4_0/base_event.go
@@ -10,11 +10,29 @@ import (
 
 type BaseEvent struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
+
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® Details: An array of <a target='_blank' href='https://attack.mitre.org'>MITRE ATT&CK®</a> objects describing identified tactics, techniques & sub-techniques.
+	Attacks []MITREATTCK `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -28,11 +46,26 @@ type BaseEvent struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
+
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -43,6 +76,15 @@ type BaseEvent struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
 
@@ -52,11 +94,23 @@ type BaseEvent struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the severity_id value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -119,22 +173,40 @@ func (v *BaseEvent) ValidateObservables() error {
 }
 
 var BaseEventFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "start_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},

--- a/ocsf/v1_4_0/cloud_resources_inventory_info.go
+++ b/ocsf/v1_4_0/cloud_resources_inventory_info.go
@@ -10,11 +10,29 @@ import (
 
 type CloudResourcesInventoryInfo struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
+
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® Details: An array of <a target='_blank' href='https://attack.mitre.org'>MITRE ATT&CK®</a> objects describing identified tactics, techniques & sub-techniques.
+	Attacks []MITREATTCK `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Discovery</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -28,6 +46,15 @@ type CloudResourcesInventoryInfo struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
+
 	// Container: A cloud-based container image or running container discovered by an inventory process.
 	Container *Container `json:"container,omitempty" parquet:"container,optional"`
 
@@ -40,6 +67,15 @@ type CloudResourcesInventoryInfo struct {
 	// Databucket: A cloud-based data bucket or other object storage discovered by an inventory process.
 	Databucket *Databucket `json:"databucket,omitempty" parquet:"databucket,optional"`
 
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
+
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
 
@@ -49,8 +85,17 @@ type CloudResourcesInventoryInfo struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
 	// Identity Provider: The Identity Provider that is being discovered by an inventory process, or that is related to the cloud resource(s) being discovered by an inventory process.
 	Idp *IdentityProvider `json:"idp,omitempty" parquet:"idp,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
 
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
@@ -61,8 +106,8 @@ type CloudResourcesInventoryInfo struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
@@ -72,6 +117,18 @@ type CloudResourcesInventoryInfo struct {
 
 	// Cloud Resources: The cloud resource(s) that are being discovered by an inventory process. Use this object if there is not a direct object match in the class.
 	Resources []ResourceDetails `json:"resources,omitempty" parquet:"resources,list,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the severity_id value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -137,27 +194,46 @@ func (v *CloudResourcesInventoryInfo) ValidateObservables() error {
 }
 
 var CloudResourcesInventoryInfoFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "container", Type: ContainerStruct, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "database", Type: DatabaseStruct, Nullable: true},
 	{Name: "databucket", Type: DatabucketStruct, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
 	{Name: "idp", Type: IdentityProviderStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "region", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "resources", Type: arrow.ListOf(ResourceDetailsStruct), Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "start_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},

--- a/ocsf/v1_4_0/compliance_finding.go
+++ b/ocsf/v1_4_0/compliance_finding.go
@@ -10,11 +10,35 @@ import (
 
 type ComplianceFinding struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the finding activity.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The finding activity name, as defined by the <code>activity_id</code>.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
+
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// Assignee: The details of the user assigned to an Incident.
+	Assignee *User `json:"assignee,omitempty" parquet:"assignee,optional"`
+
+	// Assignee Group: The details of the group assigned to an Incident.
+	AssigneeGroup *Group `json:"assignee_group,omitempty" parquet:"assignee_group,optional"`
+
+	// MITRE ATT&CK® Details: An array of <a target='_blank' href='https://attack.mitre.org'>MITRE ATT&CK®</a> objects describing identified tactics, techniques & sub-techniques.
+	Attacks []MITREATTCK `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Findings</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -28,17 +52,32 @@ type ComplianceFinding struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
-
 	// Comment: A user provided comment about the finding.
 	Comment *string `json:"comment,omitempty" parquet:"comment,optional"`
 
 	// Compliance: The compliance object provides context to compliance findings (e.g., a check against a specific regulatory or best practice framework such as CIS, NIST etc.) and contains compliance related details.
 	Compliance Compliance `json:"compliance" parquet:"compliance"`
 
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
+
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
+
+	// Device: Describes the affected device/host. It can be used in conjunction with <code>Affected Resource(s)</code>. <p> e.g. Specific details about an AWS EC2 instance, that is affected by the Finding.</p>
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -55,6 +94,27 @@ type ComplianceFinding struct {
 	// Finding Information: Describes the supporting information about a generated finding.
 	FindingInfo FindingInformation `json:"finding_info" parquet:"finding_info"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Impact: The impact , normalized to the caption of the impact_id value. In the case of 'Other', it is defined by the event source.
+	Impact *string `json:"impact,omitempty" parquet:"impact,optional"`
+
+	// Impact ID: The normalized impact of the incident or finding. Per NIST, this is the magnitude of harm that can be expected to result from the consequences of unauthorized disclosure, modification, destruction, or loss of information or information system availability.
+	ImpactId *int32 `json:"impact_id,omitempty" parquet:"impact_id,optional"`
+
+	// Impact Score: The impact as an integer value of the finding, valid range 0-100.
+	ImpactScore *int32 `json:"impact_score,omitempty" parquet:"impact_score,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Suspected Breach: A determination based on analytics as to whether a potential breach was found.
+	IsSuspectedBreach *bool `json:"is_suspected_breach,omitempty" parquet:"is_suspected_breach,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
 
@@ -64,8 +124,14 @@ type ComplianceFinding struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
+
+	// Priority: The priority, normalized to the caption of the priority_id value. In the case of 'Other', it is defined by the event source.
+	Priority *string `json:"priority,omitempty" parquet:"priority,optional"`
+
+	// Priority ID: The normalized priority. Priority identifies the relative importance of the incident or finding. It is a measurement of urgency.
+	PriorityId *int32 `json:"priority_id,omitempty" parquet:"priority_id,optional"`
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
@@ -76,11 +142,26 @@ type ComplianceFinding struct {
 	// Resources Array: Describes details about the resource/resouces that are the subject of the compliance check.
 	Resources []ResourceDetails `json:"resources,omitempty" parquet:"resources,list,optional"`
 
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
+
 	// Severity: The event/finding severity, normalized to the caption of the severity_id value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
 
 	// Severity ID: <p>The normalized identifier of the event/finding severity.</p>The normalized severity is a measurement the effort and expense required to manage and resolve an event or incident. Smaller numerical values represent lower impact events, and larger numerical values represent higher impact events.
 	SeverityId int32 `json:"severity_id" parquet:"severity_id"`
+
+	// Source URL: A Url link used to access the original incident.
+	SrcUrl *string `json:"src_url,omitempty" parquet:"src_url,optional"`
 
 	// Start Time: The time of the least recent event included in the finding.
 	StartTime int64 `json:"start_time,omitempty" parquet:"start_time,timestamp_millis,timestamp(millisecond),optional"`
@@ -96,6 +177,9 @@ type ComplianceFinding struct {
 
 	// Status ID: The normalized status identifier of the Finding, set by the consumer.
 	StatusId *int32 `json:"status_id,omitempty" parquet:"status_id,optional"`
+
+	// Ticket: The linked ticket in the ticketing system.
+	Ticket *Ticket `json:"ticket,omitempty" parquet:"ticket,optional"`
 
 	// Event Time: The normalized event occurrence time or the finding creation time.
 	Time int64 `json:"time" parquet:"time,timestamp_millis,timestamp(millisecond)"`
@@ -114,6 +198,12 @@ type ComplianceFinding struct {
 
 	// Vendor Attributes: The Vendor Attributes object can be used to represent values of attributes populated by the Vendor/Finding Provider. It can help distinguish between the vendor-prodvided values and consumer-updated values, of key attributes like <code>severity_id</code>.<br>The original finding producer should not populate this object. It should be populated by consuming systems that support data mutability.
 	VendorAttributes *VendorAttributes `json:"vendor_attributes,omitempty" parquet:"vendor_attributes,optional"`
+
+	// Verdict: The verdict assigned to an Incident finding.
+	Verdict *string `json:"verdict,omitempty" parquet:"verdict,optional"`
+
+	// Verdict ID: The normalized verdict of an Incident.
+	VerdictId *int32 `json:"verdict_id,omitempty" parquet:"verdict_id,optional"`
 }
 
 func (v *ComplianceFinding) Observable() (*int, string) {
@@ -140,41 +230,71 @@ func (v *ComplianceFinding) ValidateObservables() error {
 }
 
 var ComplianceFindingFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "assignee", Type: UserStruct, Nullable: true},
+	{Name: "assignee_group", Type: GroupStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
 	{Name: "comment", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "compliance", Type: ComplianceStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
 	{Name: "evidences", Type: arrow.ListOf(EvidenceArtifactsStruct), Nullable: true},
 	{Name: "finding_info", Type: FindingInformationStruct, Nullable: false},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "impact", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "impact_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "impact_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "is_suspected_breach", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
+	{Name: "priority", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "priority_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "remediation", Type: RemediationStruct, Nullable: true},
 	{Name: "resources", Type: arrow.ListOf(ResourceDetailsStruct), Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
+	{Name: "src_url", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "start_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "status", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "status_code", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "status_detail", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "status_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "ticket", Type: TicketStruct, Nullable: true},
 	{Name: "time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: false},
 	{Name: "timezone_offset", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "type_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "type_uid", Type: arrow.PrimitiveTypes.Int64, Nullable: false},
 	{Name: "unmapped", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "vendor_attributes", Type: VendorAttributesStruct, Nullable: true},
+	{Name: "verdict", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "verdict_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 }
 
 var ComplianceFindingStruct = arrow.StructOf(ComplianceFindingFields...)

--- a/ocsf/v1_4_0/config_state.go
+++ b/ocsf/v1_4_0/config_state.go
@@ -10,11 +10,29 @@ import (
 
 type DeviceConfigState struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
+
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® Details: An array of <a target='_blank' href='https://attack.mitre.org'>MITRE ATT&CK®</a> objects describing identified tactics, techniques & sub-techniques.
+	Attacks []MITREATTCK `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Discovery</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -31,14 +49,26 @@ type DeviceConfigState struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
 
 	// Device: The device that is being discovered by an inventory process.
 	Device Device `json:"device" parquet:"device"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -49,6 +79,15 @@ type DeviceConfigState struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
 
@@ -58,11 +97,23 @@ type DeviceConfigState struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the severity_id value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -125,24 +176,41 @@ func (v *DeviceConfigState) ValidateObservables() error {
 }
 
 var DeviceConfigStateFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "cis_benchmark_result", Type: CISBenchmarkResultStruct, Nullable: true},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "device", Type: DeviceStruct, Nullable: false},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "start_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},

--- a/ocsf/v1_4_0/data_security_finding.go
+++ b/ocsf/v1_4_0/data_security_finding.go
@@ -10,11 +10,35 @@ import (
 
 type DataSecurityFinding struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the Data Security Finding activity.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The Data Security finding activity name, as defined by the <code>activity_id</code>.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
+
+	// Actor: Describes details about the actor implicated in the data security finding. Either an actor that owns a particular digital file or information store, or an actor which accessed classified or sensitive data.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// Assignee: The details of the user assigned to an Incident.
+	Assignee *User `json:"assignee,omitempty" parquet:"assignee,optional"`
+
+	// Assignee Group: The details of the group assigned to an Incident.
+	AssigneeGroup *Group `json:"assignee_group,omitempty" parquet:"assignee_group,optional"`
+
+	// MITRE ATT&CK® Details: An array of <a target='_blank' href='https://attack.mitre.org'>MITRE ATT&CK®</a> objects describing identified tactics, techniques & sub-techniques.
+	Attacks []MITREATTCK `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Findings</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -28,11 +52,17 @@ type DataSecurityFinding struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
-
 	// Comment: A user provided comment about the finding.
 	Comment *string `json:"comment,omitempty" parquet:"comment,optional"`
+
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
@@ -45,6 +75,15 @@ type DataSecurityFinding struct {
 
 	// Databucket: Describes the databucket where classified or sensitive data is stored in, or was accessed from. The data bucket object is a basic container that holds data, typically organized through the use of data partitions.
 	Databucket *Databucket `json:"databucket,omitempty" parquet:"databucket,optional"`
+
+	// Device: Describes the device where classified or sensitive data is stored in, or was accessed from.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Destination Endpoint: Describes the endpoint where classified or sensitive data is stored in, or was accessed from.
 	DstEndpoint *NetworkEndpoint `json:"dst_endpoint,omitempty" parquet:"dst_endpoint,optional"`
@@ -64,6 +103,27 @@ type DataSecurityFinding struct {
 	// Finding Information: Describes the supporting information about a generated finding.
 	FindingInfo FindingInformation `json:"finding_info" parquet:"finding_info"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Impact: The impact , normalized to the caption of the impact_id value. In the case of 'Other', it is defined by the event source.
+	Impact *string `json:"impact,omitempty" parquet:"impact,optional"`
+
+	// Impact ID: The normalized impact of the incident or finding. Per NIST, this is the magnitude of harm that can be expected to result from the consequences of unauthorized disclosure, modification, destruction, or loss of information or information system availability.
+	ImpactId *int32 `json:"impact_id,omitempty" parquet:"impact_id,optional"`
+
+	// Impact Score: The impact as an integer value of the finding, valid range 0-100.
+	ImpactScore *int32 `json:"impact_score,omitempty" parquet:"impact_score,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. For example, an <code>activity_id</code> of 'Create' could constitute an alertable signal and the value would be <code>true</code>, while 'Close' likely would not and either omit the attribute or set its value to <code>false</code>.  Note that other events with the <code>security_control</code> profile may also be deemed alertable signals and may also carry <code>is_alert = true</code> attributes.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Suspected Breach: A determination based on analytics as to whether a potential breach was found.
+	IsSuspectedBreach *bool `json:"is_suspected_breach,omitempty" parquet:"is_suspected_breach,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
 
@@ -73,14 +133,32 @@ type DataSecurityFinding struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
+
+	// Priority: The priority, normalized to the caption of the priority_id value. In the case of 'Other', it is defined by the event source.
+	Priority *string `json:"priority,omitempty" parquet:"priority,optional"`
+
+	// Priority ID: The normalized priority. Priority identifies the relative importance of the incident or finding. It is a measurement of urgency.
+	PriorityId *int32 `json:"priority_id,omitempty" parquet:"priority_id,optional"`
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
 
 	// Additional Resources: Describes details about additional resources, where classified or sensitive data is stored in, or was accessed from. <p> You can populate this object, if the specific resource type objects available in the class (<code>database, databucket, table, file</code>) aren't sufficient; OR <br> You can also choose to duplicate <code>uid, name</code> of the specific resources objects, for a consistent access to resource uids across all findings.
 	Resources []ResourceDetails `json:"resources,omitempty" parquet:"resources,list,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the severity_id value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -90,6 +168,9 @@ type DataSecurityFinding struct {
 
 	// Source Endpoint: Details about the source endpoint where classified or sensitive data was accessed from.
 	SrcEndpoint *NetworkEndpoint `json:"src_endpoint,omitempty" parquet:"src_endpoint,optional"`
+
+	// Source URL: A Url link used to access the original incident.
+	SrcUrl *string `json:"src_url,omitempty" parquet:"src_url,optional"`
 
 	// Start Time: The time of the least recent event included in the finding.
 	StartTime int64 `json:"start_time,omitempty" parquet:"start_time,timestamp_millis,timestamp(millisecond),optional"`
@@ -109,6 +190,9 @@ type DataSecurityFinding struct {
 	// Table: Describes the table where classified or sensitive data is stored in, or was accessed from. The table object represents a table within a structured relational database, warehouse, lake, or similar.
 	Table *Table `json:"table,omitempty" parquet:"table,optional"`
 
+	// Ticket: The linked ticket in the ticketing system.
+	Ticket *Ticket `json:"ticket,omitempty" parquet:"ticket,optional"`
+
 	// Event Time: The normalized event occurrence time or the finding creation time.
 	Time int64 `json:"time" parquet:"time,timestamp_millis,timestamp(millisecond)"`
 
@@ -126,6 +210,12 @@ type DataSecurityFinding struct {
 
 	// Vendor Attributes: The Vendor Attributes object can be used to represent values of attributes populated by the Vendor/Finding Provider. It can help distinguish between the vendor-prodvided values and consumer-updated values, of key attributes like <code>severity_id</code>.<br>The original finding producer should not populate this object. It should be populated by consuming systems that support data mutability.
 	VendorAttributes *VendorAttributes `json:"vendor_attributes,omitempty" parquet:"vendor_attributes,optional"`
+
+	// Verdict: The verdict assigned to an Incident finding.
+	Verdict *string `json:"verdict,omitempty" parquet:"verdict,optional"`
+
+	// Verdict ID: The normalized verdict of an Incident.
+	VerdictId *int32 `json:"verdict_id,omitempty" parquet:"verdict_id,optional"`
 }
 
 func (v *DataSecurityFinding) Observable() (*int, string) {
@@ -152,45 +242,75 @@ func (v *DataSecurityFinding) ValidateObservables() error {
 }
 
 var DataSecurityFindingFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "assignee", Type: UserStruct, Nullable: true},
+	{Name: "assignee_group", Type: GroupStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
 	{Name: "comment", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "data_security", Type: DataSecurityStruct, Nullable: true},
 	{Name: "database", Type: DatabaseStruct, Nullable: true},
 	{Name: "databucket", Type: DatabucketStruct, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "dst_endpoint", Type: NetworkEndpointStruct, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
 	{Name: "file", Type: FileStruct, Nullable: true},
 	{Name: "finding_info", Type: FindingInformationStruct, Nullable: false},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "impact", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "impact_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "impact_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "is_suspected_breach", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
+	{Name: "priority", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "priority_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "resources", Type: arrow.ListOf(ResourceDetailsStruct), Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "src_endpoint", Type: NetworkEndpointStruct, Nullable: true},
+	{Name: "src_url", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "start_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "status", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "status_code", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "status_detail", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "status_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "table", Type: TableStruct, Nullable: true},
+	{Name: "ticket", Type: TicketStruct, Nullable: true},
 	{Name: "time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: false},
 	{Name: "timezone_offset", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "type_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "type_uid", Type: arrow.PrimitiveTypes.Int64, Nullable: false},
 	{Name: "unmapped", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "vendor_attributes", Type: VendorAttributesStruct, Nullable: true},
+	{Name: "verdict", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "verdict_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 }
 
 var DataSecurityFindingStruct = arrow.StructOf(DataSecurityFindingFields...)

--- a/ocsf/v1_4_0/datastore_activity.go
+++ b/ocsf/v1_4_0/datastore_activity.go
@@ -10,6 +10,12 @@ import (
 
 type DatastoreActivity struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
@@ -18,6 +24,15 @@ type DatastoreActivity struct {
 
 	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
 	Actor Actor `json:"actor" parquet:"actor"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® Details: An array of <a target='_blank' href='https://attack.mitre.org'>MITRE ATT&CK®</a> objects describing identified tactics, techniques & sub-techniques.
+	Attacks []MITREATTCK `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Application Activity</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -31,8 +46,14 @@ type DatastoreActivity struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
@@ -42,6 +63,15 @@ type DatastoreActivity struct {
 
 	// Databucket: The data bucket object is a basic container that holds data, typically organized through the use of data partitions.
 	Databucket *Databucket `json:"databucket,omitempty" parquet:"databucket,optional"`
+
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Destination Endpoint: Details about the endpoint hosting the datastore application or service.
 	DstEndpoint *NetworkEndpoint `json:"dst_endpoint,omitempty" parquet:"dst_endpoint,optional"`
@@ -55,11 +85,20 @@ type DatastoreActivity struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
 	// HTTP Request: Details about the underlying http request.
 	HttpRequest *HTTPRequest `json:"http_request,omitempty" parquet:"http_request,optional"`
 
 	// HTTP Response: Details about the underlying http response.
 	HttpResponse *HTTPResponse `json:"http_response,omitempty" parquet:"http_response,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
 
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
@@ -70,14 +109,26 @@ type DatastoreActivity struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Query Info: The query info object holds information related to data access within a datastore. To access, manipulate, delete, or retrieve data from a datastore, a database query must be written using a specific syntax.
 	QueryInfo *QueryInformation `json:"query_info,omitempty" parquet:"query_info,optional"`
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the severity_id value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -152,29 +203,46 @@ func (v *DatastoreActivity) ValidateObservables() error {
 }
 
 var DatastoreActivityFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "actor", Type: ActorStruct, Nullable: false},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "database", Type: DatabaseStruct, Nullable: true},
 	{Name: "databucket", Type: DatabucketStruct, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "dst_endpoint", Type: NetworkEndpointStruct, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
 	{Name: "http_request", Type: HTTPRequestStruct, Nullable: true},
 	{Name: "http_response", Type: HTTPResponseStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "query_info", Type: QueryInformationStruct, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "src_endpoint", Type: NetworkEndpointStruct, Nullable: false},

--- a/ocsf/v1_4_0/detection_finding.go
+++ b/ocsf/v1_4_0/detection_finding.go
@@ -10,11 +10,35 @@ import (
 
 type DetectionFinding struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the finding activity.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The finding activity name, as defined by the <code>activity_id</code>.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
+
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// Assignee: The details of the user assigned to an Incident.
+	Assignee *User `json:"assignee,omitempty" parquet:"assignee,optional"`
+
+	// Assignee Group: The details of the group assigned to an Incident.
+	AssigneeGroup *Group `json:"assignee_group,omitempty" parquet:"assignee_group,optional"`
+
+	// MITRE ATT&CK® Details: An array of <a target='_blank' href='https://attack.mitre.org'>MITRE ATT&CK®</a> objects describing identified tactics, techniques & sub-techniques.
+	Attacks []MITREATTCK `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Findings</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -28,14 +52,29 @@ type DetectionFinding struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
-
 	// Comment: A user provided comment about the finding.
 	Comment *string `json:"comment,omitempty" parquet:"comment,optional"`
 
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
+
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
+
+	// Device: Describes the affected device/host. It can be used in conjunction with <code>Affected Resource(s)</code>. <p> e.g. Specific details about an AWS EC2 instance, that is affected by the Finding.</p>
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -52,6 +91,27 @@ type DetectionFinding struct {
 	// Finding Information: Describes the supporting information about a generated finding.
 	FindingInfo FindingInformation `json:"finding_info" parquet:"finding_info"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Impact: The impact , normalized to the caption of the impact_id value. In the case of 'Other', it is defined by the event source.
+	Impact *string `json:"impact,omitempty" parquet:"impact,optional"`
+
+	// Impact ID: The normalized impact of the incident or finding. Per NIST, this is the magnitude of harm that can be expected to result from the consequences of unauthorized disclosure, modification, destruction, or loss of information or information system availability.
+	ImpactId *int32 `json:"impact_id,omitempty" parquet:"impact_id,optional"`
+
+	// Impact Score: The impact as an integer value of the finding, valid range 0-100.
+	ImpactScore *int32 `json:"impact_score,omitempty" parquet:"impact_score,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. For example, an <code>activity_id</code> of 'Create' could constitute an alertable signal and the value would be <code>true</code>, while 'Close' likely would not and either omit the attribute or set its value to <code>false</code>.  Note that other events with the <code>security_control</code> profile may also be deemed alertable signals and may also carry <code>is_alert = true</code> attributes.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Suspected Breach: A determination based on analytics as to whether a potential breach was found.
+	IsSuspectedBreach *bool `json:"is_suspected_breach,omitempty" parquet:"is_suspected_breach,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
 
@@ -61,8 +121,14 @@ type DetectionFinding struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
+
+	// Priority: The priority, normalized to the caption of the priority_id value. In the case of 'Other', it is defined by the event source.
+	Priority *string `json:"priority,omitempty" parquet:"priority,optional"`
+
+	// Priority ID: The normalized priority. Priority identifies the relative importance of the incident or finding. It is a measurement of urgency.
+	PriorityId *int32 `json:"priority_id,omitempty" parquet:"priority_id,optional"`
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
@@ -73,11 +139,26 @@ type DetectionFinding struct {
 	// Affected Resources: Describes details about resources that were the target of the activity that triggered the finding.
 	Resources []ResourceDetails `json:"resources,omitempty" parquet:"resources,list,optional"`
 
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
+
 	// Severity: The event/finding severity, normalized to the caption of the severity_id value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
 
 	// Severity ID: <p>The normalized identifier of the event/finding severity.</p>The normalized severity is a measurement the effort and expense required to manage and resolve an event or incident. Smaller numerical values represent lower impact events, and larger numerical values represent higher impact events.
 	SeverityId int32 `json:"severity_id" parquet:"severity_id"`
+
+	// Source URL: A Url link used to access the original incident.
+	SrcUrl *string `json:"src_url,omitempty" parquet:"src_url,optional"`
 
 	// Start Time: The time of the least recent event included in the finding.
 	StartTime int64 `json:"start_time,omitempty" parquet:"start_time,timestamp_millis,timestamp(millisecond),optional"`
@@ -93,6 +174,9 @@ type DetectionFinding struct {
 
 	// Status ID: The normalized status identifier of the Finding, set by the consumer.
 	StatusId *int32 `json:"status_id,omitempty" parquet:"status_id,optional"`
+
+	// Ticket: The linked ticket in the ticketing system.
+	Ticket *Ticket `json:"ticket,omitempty" parquet:"ticket,optional"`
 
 	// Event Time: The normalized event occurrence time or the finding creation time.
 	Time int64 `json:"time" parquet:"time,timestamp_millis,timestamp(millisecond)"`
@@ -111,6 +195,12 @@ type DetectionFinding struct {
 
 	// Vendor Attributes: The Vendor Attributes object can be used to represent values of attributes populated by the Vendor/Finding Provider. It can help distinguish between the vendor-prodvided values and consumer-updated values, of key attributes like <code>severity_id</code>.<br>The original finding producer should not populate this object. It should be populated by consuming systems that support data mutability.
 	VendorAttributes *VendorAttributes `json:"vendor_attributes,omitempty" parquet:"vendor_attributes,optional"`
+
+	// Verdict: The verdict assigned to an Incident finding.
+	Verdict *string `json:"verdict,omitempty" parquet:"verdict,optional"`
+
+	// Verdict ID: The normalized verdict of an Incident.
+	VerdictId *int32 `json:"verdict_id,omitempty" parquet:"verdict_id,optional"`
 
 	// Vulnerabilities: Describes vulnerabilities reported in a Detection Finding.
 	Vulnerabilities []VulnerabilityDetails `json:"vulnerabilities,omitempty" parquet:"vulnerabilities,list,optional"`
@@ -140,40 +230,70 @@ func (v *DetectionFinding) ValidateObservables() error {
 }
 
 var DetectionFindingFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "assignee", Type: UserStruct, Nullable: true},
+	{Name: "assignee_group", Type: GroupStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
 	{Name: "comment", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
 	{Name: "evidences", Type: arrow.ListOf(EvidenceArtifactsStruct), Nullable: true},
 	{Name: "finding_info", Type: FindingInformationStruct, Nullable: false},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "impact", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "impact_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "impact_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "is_suspected_breach", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
+	{Name: "priority", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "priority_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "remediation", Type: RemediationStruct, Nullable: true},
 	{Name: "resources", Type: arrow.ListOf(ResourceDetailsStruct), Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
+	{Name: "src_url", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "start_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "status", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "status_code", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "status_detail", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "status_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "ticket", Type: TicketStruct, Nullable: true},
 	{Name: "time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: false},
 	{Name: "timezone_offset", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "type_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "type_uid", Type: arrow.PrimitiveTypes.Int64, Nullable: false},
 	{Name: "unmapped", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "vendor_attributes", Type: VendorAttributesStruct, Nullable: true},
+	{Name: "verdict", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "verdict_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "vulnerabilities", Type: arrow.ListOf(VulnerabilityDetailsStruct), Nullable: true},
 }
 

--- a/ocsf/v1_4_0/device_config_state_change.go
+++ b/ocsf/v1_4_0/device_config_state_change.go
@@ -10,11 +10,29 @@ import (
 
 type DeviceConfigStateChange struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
+
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® Details: An array of <a target='_blank' href='https://attack.mitre.org'>MITRE ATT&CK®</a> objects describing identified tactics, techniques & sub-techniques.
+	Attacks []MITREATTCK `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Discovery</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -28,14 +46,26 @@ type DeviceConfigStateChange struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
 
 	// Device: The device that is impacted by the state change.
 	Device Device `json:"device" parquet:"device"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -46,6 +76,15 @@ type DeviceConfigStateChange struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
 
@@ -55,8 +94,8 @@ type DeviceConfigStateChange struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Previous Security Level: The previous security level of the entity
 	PrevSecurityLevel *string `json:"prev_security_level,omitempty" parquet:"prev_security_level,optional"`
@@ -69,6 +108,18 @@ type DeviceConfigStateChange struct {
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Security Level: The current security level of the entity
 	SecurityLevel *string `json:"security_level,omitempty" parquet:"security_level,optional"`
@@ -146,26 +197,43 @@ func (v *DeviceConfigStateChange) ValidateObservables() error {
 }
 
 var DeviceConfigStateChangeFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "device", Type: DeviceStruct, Nullable: false},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "prev_security_level", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "prev_security_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "prev_security_states", Type: arrow.ListOf(SecurityStateStruct), Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "security_level", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "security_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "security_states", Type: arrow.ListOf(SecurityStateStruct), Nullable: true},

--- a/ocsf/v1_4_0/dhcp_activity.go
+++ b/ocsf/v1_4_0/dhcp_activity.go
@@ -10,14 +10,32 @@ import (
 
 type DHCPActivity struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
 
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
 	// Application Name: The name of the application associated with the event or object.
 	AppName *string `json:"app_name,omitempty" parquet:"app_name,optional"`
+
+	// MITRE ATT&CK® Details: An array of <a target='_blank' href='https://attack.mitre.org'>MITRE ATT&CK®</a> objects describing identified tactics, techniques & sub-techniques.
+	Attacks []MITREATTCK `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Network Activity</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -31,14 +49,29 @@ type DHCPActivity struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Connection Info: The network connection information.
 	ConnectionInfo *NetworkConnectionInformation `json:"connection_info,omitempty" parquet:"connection_info,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
+
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Destination Endpoint: The responder (server) of the DHCP connection.
 	DstEndpoint *NetworkEndpoint `json:"dst_endpoint,omitempty" parquet:"dst_endpoint,optional"`
@@ -52,6 +85,12 @@ type DHCPActivity struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
 	// Renewal: The indication of whether this is a lease/session renewal event.
 	IsRenewal *bool `json:"is_renewal,omitempty" parquet:"is_renewal,optional"`
 
@@ -60,6 +99,9 @@ type DHCPActivity struct {
 
 	// Lease Duration: This represents the length of the DHCP lease in seconds. This is present in DHCP Ack events.
 	LeaseDur *int32 `json:"lease_dur,omitempty" parquet:"lease_dur,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
 
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
@@ -70,14 +112,44 @@ type DHCPActivity struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
+
+	// Proxy Connection Info: The connection information from the proxy server to the remote server.
+	ProxyConnectionInfo *NetworkConnectionInformation `json:"proxy_connection_info,omitempty" parquet:"proxy_connection_info,optional"`
+
+	// Proxy Endpoint: The proxy (server) in a network connection.
+	ProxyEndpoint *NetworkProxyEndpoint `json:"proxy_endpoint,omitempty" parquet:"proxy_endpoint,optional"`
+
+	// Proxy HTTP Request: The HTTP Request from the proxy server to the remote server.
+	ProxyHttpRequest *HTTPRequest `json:"proxy_http_request,omitempty" parquet:"proxy_http_request,optional"`
+
+	// Proxy HTTP Response: The HTTP Response from the remote server to the proxy server.
+	ProxyHttpResponse *HTTPResponse `json:"proxy_http_response,omitempty" parquet:"proxy_http_response,optional"`
+
+	// Proxy TLS: The TLS protocol negotiated between the proxy server and the remote server.
+	ProxyTls *TransportLayerSecurityTLS `json:"proxy_tls,omitempty" parquet:"proxy_tls,optional"`
+
+	// Proxy Traffic: The network traffic refers to the amount of data moving across a network, from proxy to remote server at a given point of time.
+	ProxyTraffic *NetworkTraffic `json:"proxy_traffic,omitempty" parquet:"proxy_traffic,optional"`
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
 
 	// Relay: The network relay that is associated with the event.
 	Relay *NetworkInterface `json:"relay,omitempty" parquet:"relay,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the severity_id value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -152,29 +224,53 @@ func (v *DHCPActivity) ValidateObservables() error {
 }
 
 var DHCPActivityFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
 	{Name: "app_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "connection_info", Type: NetworkConnectionInformationStruct, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "dst_endpoint", Type: NetworkEndpointStruct, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
 	{Name: "is_renewal", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
 	{Name: "ja4_fingerprint_list", Type: arrow.ListOf(JA4FingerprintStruct), Nullable: true},
 	{Name: "lease_dur", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
+	{Name: "proxy_connection_info", Type: NetworkConnectionInformationStruct, Nullable: true},
+	{Name: "proxy_endpoint", Type: NetworkProxyEndpointStruct, Nullable: true},
+	{Name: "proxy_http_request", Type: HTTPRequestStruct, Nullable: true},
+	{Name: "proxy_http_response", Type: HTTPResponseStruct, Nullable: true},
+	{Name: "proxy_tls", Type: TransportLayerSecurityTLSStruct, Nullable: true},
+	{Name: "proxy_traffic", Type: NetworkTrafficStruct, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "relay", Type: NetworkInterfaceStruct, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "src_endpoint", Type: NetworkEndpointStruct, Nullable: true},

--- a/ocsf/v1_4_0/dns_activity.go
+++ b/ocsf/v1_4_0/dns_activity.go
@@ -10,17 +10,35 @@ import (
 
 type DNSActivity struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
 
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
 	// DNS Answer: The Domain Name System (DNS) answers.
 	Answers []DNSAnswer `json:"answers,omitempty" parquet:"answers,list,optional"`
 
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
 	// Application Name: The name of the application associated with the event or object.
 	AppName *string `json:"app_name,omitempty" parquet:"app_name,optional"`
+
+	// MITRE ATT&CK® Details: An array of <a target='_blank' href='https://attack.mitre.org'>MITRE ATT&CK®</a> objects describing identified tactics, techniques & sub-techniques.
+	Attacks []MITREATTCK `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Network Activity</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -34,14 +52,29 @@ type DNSActivity struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Connection Info: The network connection information.
 	ConnectionInfo *NetworkConnectionInformation `json:"connection_info,omitempty" parquet:"connection_info,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
+
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Destination Endpoint: The responder (server) in a network connection.
 	DstEndpoint *NetworkEndpoint `json:"dst_endpoint,omitempty" parquet:"dst_endpoint,optional"`
@@ -55,8 +88,17 @@ type DNSActivity struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
 	// JA4+ Fingerprints: A list of the JA4+ network fingerprints.
 	Ja4FingerprintList []JA4Fingerprint `json:"ja4_fingerprint_list,omitempty" parquet:"ja4_fingerprint_list,list,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
 
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
@@ -67,8 +109,26 @@ type DNSActivity struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
+
+	// Proxy Connection Info: The connection information from the proxy server to the remote server.
+	ProxyConnectionInfo *NetworkConnectionInformation `json:"proxy_connection_info,omitempty" parquet:"proxy_connection_info,optional"`
+
+	// Proxy Endpoint: The proxy (server) in a network connection.
+	ProxyEndpoint *NetworkProxyEndpoint `json:"proxy_endpoint,omitempty" parquet:"proxy_endpoint,optional"`
+
+	// Proxy HTTP Request: The HTTP Request from the proxy server to the remote server.
+	ProxyHttpRequest *HTTPRequest `json:"proxy_http_request,omitempty" parquet:"proxy_http_request,optional"`
+
+	// Proxy HTTP Response: The HTTP Response from the remote server to the proxy server.
+	ProxyHttpResponse *HTTPResponse `json:"proxy_http_response,omitempty" parquet:"proxy_http_response,optional"`
+
+	// Proxy TLS: The TLS protocol negotiated between the proxy server and the remote server.
+	ProxyTls *TransportLayerSecurityTLS `json:"proxy_tls,omitempty" parquet:"proxy_tls,optional"`
+
+	// Proxy Traffic: The network traffic refers to the amount of data moving across a network, from proxy to remote server at a given point of time.
+	ProxyTraffic *NetworkTraffic `json:"proxy_traffic,omitempty" parquet:"proxy_traffic,optional"`
 
 	// DNS Query: The Domain Name System (DNS) query.
 	Query *DNSQuery `json:"query,omitempty" parquet:"query,optional"`
@@ -87,6 +147,18 @@ type DNSActivity struct {
 
 	// Response Time: The Domain Name System (DNS) response time.
 	ResponseTime int64 `json:"response_time,omitempty" parquet:"response_time,timestamp_millis,timestamp(millisecond),optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the severity_id value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -158,32 +230,56 @@ func (v *DNSActivity) ValidateObservables() error {
 }
 
 var DNSActivityFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
 	{Name: "answers", Type: arrow.ListOf(DNSAnswerStruct), Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
 	{Name: "app_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "connection_info", Type: NetworkConnectionInformationStruct, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "dst_endpoint", Type: NetworkEndpointStruct, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
 	{Name: "ja4_fingerprint_list", Type: arrow.ListOf(JA4FingerprintStruct), Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
+	{Name: "proxy_connection_info", Type: NetworkConnectionInformationStruct, Nullable: true},
+	{Name: "proxy_endpoint", Type: NetworkProxyEndpointStruct, Nullable: true},
+	{Name: "proxy_http_request", Type: HTTPRequestStruct, Nullable: true},
+	{Name: "proxy_http_response", Type: HTTPResponseStruct, Nullable: true},
+	{Name: "proxy_tls", Type: TransportLayerSecurityTLSStruct, Nullable: true},
+	{Name: "proxy_traffic", Type: NetworkTrafficStruct, Nullable: true},
 	{Name: "query", Type: DNSQueryStruct, Nullable: true},
 	{Name: "query_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "rcode", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "rcode_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "response_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "src_endpoint", Type: NetworkEndpointStruct, Nullable: true},

--- a/ocsf/v1_4_0/drone_flights_activity.go
+++ b/ocsf/v1_4_0/drone_flights_activity.go
@@ -10,17 +10,35 @@ import (
 
 type DroneFlightsActivity struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
 
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® Details: An array of <a target='_blank' href='https://attack.mitre.org'>MITRE ATT&CK®</a> objects describing identified tactics, techniques & sub-techniques.
+	Attacks []MITREATTCK `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
 	// Authentication Type: The authentication type as defined by the caption of <code>auth_protocol_id</code>. In the case of 'Other', it is defined by the event source.
 	AuthProtocol *string `json:"auth_protocol,omitempty" parquet:"auth_protocol,optional"`
 
 	// Authentication Type ID: The normalized identifier of the authentication type used to authorize a flight plan or mission.
 	AuthProtocolId *int32 `json:"auth_protocol_id,omitempty" parquet:"auth_protocol_id,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Unmanned Systems</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -37,17 +55,32 @@ type DroneFlightsActivity struct {
 	// Classification Type: UA Classification - Allows a region to classify UAS in a regional specific manner. The format may differ from region to region.
 	Classification *string `json:"classification,omitempty" parquet:"classification,optional"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
-
 	// Operation Description: This optional, free-text field enables the operator to describe the purpose of a flight, if so desired.
 	Comment *string `json:"comment,omitempty" parquet:"comment,optional"`
+
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Connection Info: The network connection information.
 	ConnectionInfo *NetworkConnectionInformation `json:"connection_info,omitempty" parquet:"connection_info,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
+
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Destination Endpoint: The destination network endpoint of the Unmanned Aerial System (UAS), Counter Unmanned Aerial System (CUAS) platform, or other unmanned systems monitoring and/or sensing infrastructure.
 	DstEndpoint NetworkEndpoint `json:"dst_endpoint" parquet:"dst_endpoint"`
@@ -61,6 +94,15 @@ type DroneFlightsActivity struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
 
@@ -70,8 +112,8 @@ type DroneFlightsActivity struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Remote ID Protocol: The networking protocol associated with the Remote ID device or beacon. E.g. <code>BLE</code>, <code>LTE</code>, <code>802.11</code>.
 	ProtocolName *string `json:"protocol_name,omitempty" parquet:"protocol_name,optional"`
@@ -81,6 +123,18 @@ type DroneFlightsActivity struct {
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the severity_id value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -161,30 +215,48 @@ func (v *DroneFlightsActivity) ValidateObservables() error {
 }
 
 var DroneFlightsActivityFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKStruct), Nullable: true},
 	{Name: "auth_protocol", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "auth_protocol_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "classification", Type: arrow.BinaryTypes.String, Nullable: true},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
 	{Name: "comment", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "connection_info", Type: NetworkConnectionInformationStruct, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "dst_endpoint", Type: NetworkEndpointStruct, Nullable: false},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "protocol_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "proxy_endpoint", Type: NetworkProxyEndpointStruct, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "src_endpoint", Type: NetworkEndpointStruct, Nullable: true},

--- a/ocsf/v1_4_0/email_activity.go
+++ b/ocsf/v1_4_0/email_activity.go
@@ -10,14 +10,32 @@ import (
 
 type EmailActivity struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
 
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® Details: An array of <a target='_blank' href='https://attack.mitre.org'>MITRE ATT&CK®</a> objects describing identified tactics, techniques & sub-techniques.
+	Attacks []MITREATTCK `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
 	// Attempt: The attempt number for attempting to deliver the email.
 	Attempt *int32 `json:"attempt,omitempty" parquet:"attempt,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Protocol Banner: The initial connection response that a messaging server receives after it connects to an email server.
 	Banner *string `json:"banner,omitempty" parquet:"banner,optional"`
@@ -34,20 +52,35 @@ type EmailActivity struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
-
 	// Command: The command issued by the initiator (client), such as SMTP HELO or EHLO.
 	Command *string `json:"command,omitempty" parquet:"command,optional"`
 
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
+
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
+
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
 
 	// Direction: The direction of the email, as defined by the <code>direction_id</code> value.
 	Direction *string `json:"direction,omitempty" parquet:"direction,optional"`
 
 	// Direction ID: <p>The direction of the email relative to the scanning host or organization.</p>Email scanned at an internet gateway might be characterized as inbound to the organization from the Internet, outbound from the organization to the Internet, or internal within the organization. Email scanned at a workstation might be characterized as inbound to, or outbound from the workstation.
 	DirectionId int32 `json:"direction_id" parquet:"direction_id"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Destination Endpoint: The responder (server) receiving the email.
 	DstEndpoint *NetworkEndpoint `json:"dst_endpoint,omitempty" parquet:"dst_endpoint,optional"`
@@ -67,6 +100,15 @@ type EmailActivity struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
 
@@ -79,14 +121,26 @@ type EmailActivity struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Protocol Name: The Protocol Name specifies the email communication protocol, such as SMTP, IMAP, or POP3.
 	ProtocolName *string `json:"protocol_name,omitempty" parquet:"protocol_name,optional"`
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the severity_id value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -152,32 +206,50 @@ func (v *EmailActivity) ValidateObservables() error {
 }
 
 var EmailActivityFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKStruct), Nullable: true},
 	{Name: "attempt", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "banner", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
 	{Name: "command", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
 	{Name: "direction", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "direction_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "dst_endpoint", Type: NetworkEndpointStruct, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "email", Type: EmailStruct, Nullable: false},
 	{Name: "email_auth", Type: EmailAuthenticationStruct, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "message_trace_uid", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "protocol_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "src_endpoint", Type: NetworkEndpointStruct, Nullable: true},

--- a/ocsf/v1_4_0/email_file_activity.go
+++ b/ocsf/v1_4_0/email_file_activity.go
@@ -10,11 +10,29 @@ import (
 
 type EmailFileActivity struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
+
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® Details: An array of <a target='_blank' href='https://attack.mitre.org'>MITRE ATT&CK®</a> objects describing identified tactics, techniques & sub-techniques.
+	Attacks []MITREATTCK `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Network Activity</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -28,11 +46,26 @@ type EmailFileActivity struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
+
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -46,6 +79,15 @@ type EmailFileActivity struct {
 	// File: The email file attachment.
 	File File `json:"file" parquet:"file"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
 
@@ -55,11 +97,23 @@ type EmailFileActivity struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the severity_id value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -122,23 +176,41 @@ func (v *EmailFileActivity) ValidateObservables() error {
 }
 
 var EmailFileActivityFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
 	{Name: "file", Type: FileStruct, Nullable: false},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "start_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},

--- a/ocsf/v1_4_0/email_url_activity.go
+++ b/ocsf/v1_4_0/email_url_activity.go
@@ -10,11 +10,29 @@ import (
 
 type EmailURLActivity struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
+
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® Details: An array of <a target='_blank' href='https://attack.mitre.org'>MITRE ATT&CK®</a> objects describing identified tactics, techniques & sub-techniques.
+	Attacks []MITREATTCK `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Network Activity</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -28,11 +46,26 @@ type EmailURLActivity struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
+
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -43,6 +76,15 @@ type EmailURLActivity struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
 
@@ -52,11 +94,23 @@ type EmailURLActivity struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the severity_id value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -122,22 +176,40 @@ func (v *EmailURLActivity) ValidateObservables() error {
 }
 
 var EmailURLActivityFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "start_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},

--- a/ocsf/v1_4_0/entity_management.go
+++ b/ocsf/v1_4_0/entity_management.go
@@ -16,11 +16,29 @@ type EntityManagement struct {
 	// Access Mask: The access mask in a platform-native format.
 	AccessMask *int32 `json:"access_mask,omitempty" parquet:"access_mask,optional"`
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
+
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® Details: An array of <a target='_blank' href='https://attack.mitre.org'>MITRE ATT&CK®</a> objects describing identified tactics, techniques & sub-techniques.
+	Attacks []MITREATTCK `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Identity & Access Management</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -34,14 +52,29 @@ type EntityManagement struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
-
 	// Comment: The user provided comment about why the entity was changed.
 	Comment *string `json:"comment,omitempty" parquet:"comment,optional"`
 
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
+
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
+
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -58,11 +91,20 @@ type EntityManagement struct {
 	// Entity Result: The updated managed entity.
 	EntityResult *ManagedEntity `json:"entity_result,omitempty" parquet:"entity_result,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
 	// HTTP Request: Details about the underlying HTTP request.
 	HttpRequest *HTTPRequest `json:"http_request,omitempty" parquet:"http_request,optional"`
 
 	// HTTP Response: Details about the underlying HTTP response.
 	HttpResponse *HTTPResponse `json:"http_response,omitempty" parquet:"http_response,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
 
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
@@ -73,11 +115,23 @@ type EntityManagement struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the severity_id value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -145,27 +199,45 @@ func (v *EntityManagement) ValidateObservables() error {
 var EntityManagementFields = []arrow.Field{
 	{Name: "access_list", Type: arrow.ListOf(arrow.BinaryTypes.String), Nullable: true},
 	{Name: "access_mask", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
 	{Name: "comment", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
 	{Name: "entity", Type: ManagedEntityStruct, Nullable: false},
 	{Name: "entity_result", Type: ManagedEntityStruct, Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
 	{Name: "http_request", Type: HTTPRequestStruct, Nullable: true},
 	{Name: "http_response", Type: HTTPResponseStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "src_endpoint", Type: NetworkEndpointStruct, Nullable: true},

--- a/ocsf/v1_4_0/event_log_actvity.go
+++ b/ocsf/v1_4_0/event_log_actvity.go
@@ -10,11 +10,29 @@ import (
 
 type EventLogActivity struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
+
+	// Actor: The actor that performed the activity.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® Details: An array of <a target='_blank' href='https://attack.mitre.org'>MITRE ATT&CK®</a> objects describing identified tactics, techniques & sub-techniques.
+	Attacks []MITREATTCK `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>System Activity</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -28,11 +46,26 @@ type EventLogActivity struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
+
+	// Device: The device that reported the event.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Destination Endpoint: The <p style='display:inline;color:red'>targeted</p> endpoint for the event log activity.
 	DstEndpoint *NetworkEndpoint `json:"dst_endpoint,omitempty" parquet:"dst_endpoint,optional"`
@@ -49,6 +82,12 @@ type EventLogActivity struct {
 	// File: The file <p style='display:inline;color:red'>targeted by</p> the activity. Example: <code>/var/log/audit.log</code>
 	File *File `json:"file,omitempty" parquet:"file,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
 	// Log Name: The name of the event log <p style='display:inline;color:red'>targeted by</p> the activity. Example: Windows <code>Security</code>.
 	LogName *string `json:"log_name,omitempty" parquet:"log_name,optional"`
 
@@ -61,6 +100,9 @@ type EventLogActivity struct {
 	// Log Type ID: The normalized log type identifier.
 	LogTypeId *int32 `json:"log_type_id,omitempty" parquet:"log_type_id,optional"`
 
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
 
@@ -70,11 +112,23 @@ type EventLogActivity struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the severity_id value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -140,28 +194,46 @@ func (v *EventLogActivity) ValidateObservables() error {
 }
 
 var EventLogActivityFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "dst_endpoint", Type: NetworkEndpointStruct, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
 	{Name: "file", Type: FileStruct, Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
 	{Name: "log_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "log_provider", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "log_type", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "log_type_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "src_endpoint", Type: NetworkEndpointStruct, Nullable: true},

--- a/ocsf/v1_4_0/file_activity.go
+++ b/ocsf/v1_4_0/file_activity.go
@@ -13,6 +13,12 @@ type FileSystemActivity struct {
 	// Access Mask: The access mask in a platform-native format.
 	AccessMask *int32 `json:"access_mask,omitempty" parquet:"access_mask,optional"`
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
@@ -21,6 +27,15 @@ type FileSystemActivity struct {
 
 	// Actor: The actor that performed the activity on the <code>file</code> object
 	Actor Actor `json:"actor" parquet:"actor"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® Details: An array of <a target='_blank' href='https://attack.mitre.org'>MITRE ATT&CK®</a> objects describing identified tactics, techniques & sub-techniques.
+	Attacks []MITREATTCK `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>System Activity</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -34,11 +49,17 @@ type FileSystemActivity struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
-
 	// Component: <p>The name or relative pathname of a sub-component of the data object, if applicable. </p>For example: <code>attachment.doc</code>, <code>attachment.zip/bad.doc</code>, or <code>part.mime/part.cab/part.uue/part.doc</code>.
 	Component *string `json:"component,omitempty" parquet:"component,optional"`
+
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Connection Identifier: The network connection identifier.
 	ConnectionUid *string `json:"connection_uid,omitempty" parquet:"connection_uid,optional"`
@@ -51,6 +72,12 @@ type FileSystemActivity struct {
 
 	// Device: An addressable device, computer system or host.
 	Device Device `json:"device" parquet:"device"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -70,6 +97,15 @@ type FileSystemActivity struct {
 	// File Result: The resulting file object when the activity was allowed and successful.
 	FileResult *File `json:"file_result,omitempty" parquet:"file_result,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
 
@@ -79,11 +115,23 @@ type FileSystemActivity struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the severity_id value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -147,30 +195,46 @@ func (v *FileSystemActivity) ValidateObservables() error {
 
 var FileSystemActivityFields = []arrow.Field{
 	{Name: "access_mask", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "actor", Type: ActorStruct, Nullable: false},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
 	{Name: "component", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "connection_uid", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "create_mask", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "device", Type: DeviceStruct, Nullable: false},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
 	{Name: "file", Type: FileStruct, Nullable: false},
 	{Name: "file_diff", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "file_result", Type: FileStruct, Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "start_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},

--- a/ocsf/v1_4_0/file_hosting.go
+++ b/ocsf/v1_4_0/file_hosting.go
@@ -19,6 +19,12 @@ type FileHostingActivity struct {
 	// Access Check Result: The list of access check results.
 	AccessResult *string `json:"access_result,omitempty" parquet:"access_result,optional"`
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
@@ -27,6 +33,15 @@ type FileHostingActivity struct {
 
 	// Actor: The actor that performed the activity on the target file.
 	Actor Actor `json:"actor" parquet:"actor"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® Details: An array of <a target='_blank' href='https://attack.mitre.org'>MITRE ATT&CK®</a> objects describing identified tactics, techniques & sub-techniques.
+	Attacks []MITREATTCK `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Application Activity</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -40,14 +55,29 @@ type FileHostingActivity struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Connection Info: The network connection information.
 	ConnectionInfo *NetworkConnectionInformation `json:"connection_info,omitempty" parquet:"connection_info,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
+
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Destination Endpoint: The endpoint that received the activity on the target file.
 	DstEndpoint *NetworkEndpoint `json:"dst_endpoint,omitempty" parquet:"dst_endpoint,optional"`
@@ -70,6 +100,15 @@ type FileHostingActivity struct {
 	// File Result: The resulting file object when the activity was allowed and successful.
 	FileResult *File `json:"file_result,omitempty" parquet:"file_result,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
 
@@ -79,11 +118,23 @@ type FileHostingActivity struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the severity_id value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -161,16 +212,26 @@ var FileHostingActivityFields = []arrow.Field{
 	{Name: "access_list", Type: arrow.ListOf(arrow.BinaryTypes.String), Nullable: true},
 	{Name: "access_mask", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "access_result", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "actor", Type: ActorStruct, Nullable: false},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "connection_info", Type: NetworkConnectionInformationStruct, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "dst_endpoint", Type: NetworkEndpointStruct, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
@@ -178,11 +239,18 @@ var FileHostingActivityFields = []arrow.Field{
 	{Name: "expiration_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "file", Type: FileStruct, Nullable: false},
 	{Name: "file_result", Type: FileStruct, Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "share", Type: arrow.BinaryTypes.String, Nullable: true},

--- a/ocsf/v1_4_0/file_query.go
+++ b/ocsf/v1_4_0/file_query.go
@@ -10,11 +10,29 @@ import (
 
 type FileQuery struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
+
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® Details: An array of <a target='_blank' href='https://attack.mitre.org'>MITRE ATT&CK®</a> objects describing identified tactics, techniques & sub-techniques.
+	Attacks []MITREATTCK `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Discovery</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -28,11 +46,26 @@ type FileQuery struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
+
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -46,6 +79,15 @@ type FileQuery struct {
 	// File: The file that is the target of the query.
 	File File `json:"file" parquet:"file"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
 
@@ -55,8 +97,8 @@ type FileQuery struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Query Info: The search details associated with the query request.
 	QueryInfo *QueryInformation `json:"query_info,omitempty" parquet:"query_info,optional"`
@@ -69,6 +111,18 @@ type FileQuery struct {
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the severity_id value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -131,26 +185,44 @@ func (v *FileQuery) ValidateObservables() error {
 }
 
 var FileQueryFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
 	{Name: "file", Type: FileStruct, Nullable: false},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "query_info", Type: QueryInformationStruct, Nullable: true},
 	{Name: "query_result", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "query_result_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "start_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},

--- a/ocsf/v1_4_0/file_remediation_activity.go
+++ b/ocsf/v1_4_0/file_remediation_activity.go
@@ -10,11 +10,29 @@ import (
 
 type FileRemediationActivity struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: Matches the MITRE D3FEND™ Tactic. Note: the Model and Detect Tactics are not supported as remediations by the OCSF Remediation event class.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
+
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® Details: An array of <a target='_blank' href='https://attack.mitre.org'>MITRE ATT&CK®</a> objects describing identified tactics, techniques & sub-techniques.
+	Attacks []MITREATTCK `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Remediation</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -28,17 +46,32 @@ type FileRemediationActivity struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
-
 	// Command UID: The unique identifier of the remediation command that pertains to this event.
 	CommandUid string `json:"command_uid" parquet:"command_uid"`
+
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
 
 	// Countermeasures: The MITRE DEFEND™ Matrix Countermeasures associated with a remediation.
 	Countermeasures []MITRED3FEND `json:"countermeasures,omitempty" parquet:"countermeasures,list,optional"`
+
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -52,6 +85,15 @@ type FileRemediationActivity struct {
 	// File: The file that pertains to the remediation event.
 	File File `json:"file" parquet:"file"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
 
@@ -61,14 +103,26 @@ type FileRemediationActivity struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
 
 	// Remediation Guidance: Describes the recommended remediation steps to address identified issue(s).
 	Remediation *Remediation `json:"remediation,omitempty" parquet:"remediation,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Scan: The remediation scan that pertains to this event.
 	Scan *Scan `json:"scan,omitempty" parquet:"scan,optional"`
@@ -134,26 +188,44 @@ func (v *FileRemediationActivity) ValidateObservables() error {
 }
 
 var FileRemediationActivityFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
 	{Name: "command_uid", Type: arrow.BinaryTypes.String, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "countermeasures", Type: arrow.ListOf(MITRED3FENDStruct), Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
 	{Name: "file", Type: FileStruct, Nullable: false},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "remediation", Type: RemediationStruct, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "scan", Type: ScanStruct, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},

--- a/ocsf/v1_4_0/folder_query.go
+++ b/ocsf/v1_4_0/folder_query.go
@@ -10,11 +10,29 @@ import (
 
 type FolderQuery struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
+
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® Details: An array of <a target='_blank' href='https://attack.mitre.org'>MITRE ATT&CK®</a> objects describing identified tactics, techniques & sub-techniques.
+	Attacks []MITREATTCK `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Discovery</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -28,11 +46,26 @@ type FolderQuery struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
+
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -43,8 +76,17 @@ type FolderQuery struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
 	// Folder: The folder that is the target of the query.
 	Folder File `json:"folder" parquet:"folder"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
 
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
@@ -55,8 +97,8 @@ type FolderQuery struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Query Info: The search details associated with the query request.
 	QueryInfo *QueryInformation `json:"query_info,omitempty" parquet:"query_info,optional"`
@@ -69,6 +111,18 @@ type FolderQuery struct {
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the severity_id value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -131,26 +185,44 @@ func (v *FolderQuery) ValidateObservables() error {
 }
 
 var FolderQueryFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
 	{Name: "folder", Type: FileStruct, Nullable: false},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "query_info", Type: QueryInformationStruct, Nullable: true},
 	{Name: "query_result", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "query_result_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "start_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},

--- a/ocsf/v1_4_0/ftp_activity.go
+++ b/ocsf/v1_4_0/ftp_activity.go
@@ -10,14 +10,32 @@ import (
 
 type FTPActivity struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
 
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
 	// Application Name: The name of the application associated with the event or object.
 	AppName *string `json:"app_name,omitempty" parquet:"app_name,optional"`
+
+	// MITRE ATT&CK® Details: An array of <a target='_blank' href='https://attack.mitre.org'>MITRE ATT&CK®</a> objects describing identified tactics, techniques & sub-techniques.
+	Attacks []MITREATTCK `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Network Activity</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -31,9 +49,6 @@ type FTPActivity struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
-
 	// Response Codes: The list of return codes to the FTP command.
 	Codes []int32 `json:"codes,omitempty" parquet:"codes,list,optional"`
 
@@ -43,11 +58,29 @@ type FTPActivity struct {
 	// Command Responses: The list of responses to the FTP command.
 	CommandResponses []string `json:"command_responses,omitempty" parquet:"command_responses,list,optional"`
 
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
+
 	// Connection Info: The network connection information.
 	ConnectionInfo *NetworkConnectionInformation `json:"connection_info,omitempty" parquet:"connection_info,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
+
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Destination Endpoint: The responder (server) in a network connection.
 	DstEndpoint *NetworkEndpoint `json:"dst_endpoint,omitempty" parquet:"dst_endpoint,optional"`
@@ -64,8 +97,17 @@ type FTPActivity struct {
 	// File: The file that is the target of the FTP activity.
 	File *File `json:"file,omitempty" parquet:"file,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
 	// JA4+ Fingerprints: A list of the JA4+ network fingerprints.
 	Ja4FingerprintList []JA4Fingerprint `json:"ja4_fingerprint_list,omitempty" parquet:"ja4_fingerprint_list,list,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
 
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
@@ -79,14 +121,44 @@ type FTPActivity struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Port: The dynamic port established for impending data transfers.
 	Port *int32 `json:"port,omitempty" parquet:"port,optional"`
 
+	// Proxy Connection Info: The connection information from the proxy server to the remote server.
+	ProxyConnectionInfo *NetworkConnectionInformation `json:"proxy_connection_info,omitempty" parquet:"proxy_connection_info,optional"`
+
+	// Proxy Endpoint: The proxy (server) in a network connection.
+	ProxyEndpoint *NetworkProxyEndpoint `json:"proxy_endpoint,omitempty" parquet:"proxy_endpoint,optional"`
+
+	// Proxy HTTP Request: The HTTP Request from the proxy server to the remote server.
+	ProxyHttpRequest *HTTPRequest `json:"proxy_http_request,omitempty" parquet:"proxy_http_request,optional"`
+
+	// Proxy HTTP Response: The HTTP Response from the remote server to the proxy server.
+	ProxyHttpResponse *HTTPResponse `json:"proxy_http_response,omitempty" parquet:"proxy_http_response,optional"`
+
+	// Proxy TLS: The TLS protocol negotiated between the proxy server and the remote server.
+	ProxyTls *TransportLayerSecurityTLS `json:"proxy_tls,omitempty" parquet:"proxy_tls,optional"`
+
+	// Proxy Traffic: The network traffic refers to the amount of data moving across a network, from proxy to remote server at a given point of time.
+	ProxyTraffic *NetworkTraffic `json:"proxy_traffic,omitempty" parquet:"proxy_traffic,optional"`
+
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the severity_id value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -161,32 +233,56 @@ func (v *FTPActivity) ValidateObservables() error {
 }
 
 var FTPActivityFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
 	{Name: "app_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
 	{Name: "codes", Type: arrow.ListOf(arrow.PrimitiveTypes.Int32), Nullable: true},
 	{Name: "command", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "command_responses", Type: arrow.ListOf(arrow.BinaryTypes.String), Nullable: true},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "connection_info", Type: NetworkConnectionInformationStruct, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "dst_endpoint", Type: NetworkEndpointStruct, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
 	{Name: "file", Type: FileStruct, Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
 	{Name: "ja4_fingerprint_list", Type: arrow.ListOf(JA4FingerprintStruct), Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "port", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "proxy_connection_info", Type: NetworkConnectionInformationStruct, Nullable: true},
+	{Name: "proxy_endpoint", Type: NetworkProxyEndpointStruct, Nullable: true},
+	{Name: "proxy_http_request", Type: HTTPRequestStruct, Nullable: true},
+	{Name: "proxy_http_response", Type: HTTPResponseStruct, Nullable: true},
+	{Name: "proxy_tls", Type: TransportLayerSecurityTLSStruct, Nullable: true},
+	{Name: "proxy_traffic", Type: NetworkTrafficStruct, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "src_endpoint", Type: NetworkEndpointStruct, Nullable: true},

--- a/ocsf/v1_4_0/group_management.go
+++ b/ocsf/v1_4_0/group_management.go
@@ -10,11 +10,29 @@ import (
 
 type GroupManagement struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
+
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® Details: An array of <a target='_blank' href='https://attack.mitre.org'>MITRE ATT&CK®</a> objects describing identified tactics, techniques & sub-techniques.
+	Attacks []MITREATTCK `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Identity & Access Management</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -28,11 +46,26 @@ type GroupManagement struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
+
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -43,6 +76,9 @@ type GroupManagement struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
 	// Group: Group that was the target of the event.
 	Group Group `json:"group" parquet:"group"`
 
@@ -51,6 +87,12 @@ type GroupManagement struct {
 
 	// HTTP Response: Details about the underlying HTTP response.
 	HttpResponse *HTTPResponse `json:"http_response,omitempty" parquet:"http_response,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
 
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
@@ -61,8 +103,8 @@ type GroupManagement struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Privileges: A list of privileges assigned to the group.
 	Privileges []string `json:"privileges,omitempty" parquet:"privileges,list,optional"`
@@ -72,6 +114,18 @@ type GroupManagement struct {
 
 	// Resource: Resource that the privileges give access to.
 	Resource *ResourceDetails `json:"resource,omitempty" parquet:"resource,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the severity_id value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -140,27 +194,45 @@ func (v *GroupManagement) ValidateObservables() error {
 }
 
 var GroupManagementFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
 	{Name: "group", Type: GroupStruct, Nullable: false},
 	{Name: "http_request", Type: HTTPRequestStruct, Nullable: true},
 	{Name: "http_response", Type: HTTPResponseStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "privileges", Type: arrow.ListOf(arrow.BinaryTypes.String), Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "resource", Type: ResourceDetailsStruct, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "src_endpoint", Type: NetworkEndpointStruct, Nullable: true},

--- a/ocsf/v1_4_0/http_activity.go
+++ b/ocsf/v1_4_0/http_activity.go
@@ -10,14 +10,32 @@ import (
 
 type HTTPActivity struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
 
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
 	// Application Name: The name of the application associated with the event or object.
 	AppName *string `json:"app_name,omitempty" parquet:"app_name,optional"`
+
+	// MITRE ATT&CK® Details: An array of <a target='_blank' href='https://attack.mitre.org'>MITRE ATT&CK®</a> objects describing identified tactics, techniques & sub-techniques.
+	Attacks []MITREATTCK `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Network Activity</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -31,14 +49,29 @@ type HTTPActivity struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Connection Info: The network connection information.
 	ConnectionInfo *NetworkConnectionInformation `json:"connection_info,omitempty" parquet:"connection_info,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
+
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Destination Endpoint: The responder (server) in a network connection.
 	DstEndpoint *NetworkEndpoint `json:"dst_endpoint,omitempty" parquet:"dst_endpoint,optional"`
@@ -55,6 +88,9 @@ type HTTPActivity struct {
 	// File: The file that is the target of the HTTP activity.
 	File *File `json:"file,omitempty" parquet:"file,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
 	// HTTP Cookies: The cookies object describes details about HTTP cookies
 	HttpCookies []HTTPCookie `json:"http_cookies,omitempty" parquet:"http_cookies,list,optional"`
 
@@ -64,8 +100,14 @@ type HTTPActivity struct {
 	// HTTP Response: The HTTP Response from a web server to a requester.
 	HttpResponse *HTTPResponse `json:"http_response,omitempty" parquet:"http_response,optional"`
 
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
 	// JA4+ Fingerprints: A list of the JA4+ network fingerprints.
 	Ja4FingerprintList []JA4Fingerprint `json:"ja4_fingerprint_list,omitempty" parquet:"ja4_fingerprint_list,list,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
 
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
@@ -76,11 +118,41 @@ type HTTPActivity struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
+
+	// Proxy Connection Info: The connection information from the proxy server to the remote server.
+	ProxyConnectionInfo *NetworkConnectionInformation `json:"proxy_connection_info,omitempty" parquet:"proxy_connection_info,optional"`
+
+	// Proxy Endpoint: The proxy (server) in a network connection.
+	ProxyEndpoint *NetworkProxyEndpoint `json:"proxy_endpoint,omitempty" parquet:"proxy_endpoint,optional"`
+
+	// Proxy HTTP Request: The HTTP Request from the proxy server to the remote server.
+	ProxyHttpRequest *HTTPRequest `json:"proxy_http_request,omitempty" parquet:"proxy_http_request,optional"`
+
+	// Proxy HTTP Response: The HTTP Response from the remote server to the proxy server.
+	ProxyHttpResponse *HTTPResponse `json:"proxy_http_response,omitempty" parquet:"proxy_http_response,optional"`
+
+	// Proxy TLS: The TLS protocol negotiated between the proxy server and the remote server.
+	ProxyTls *TransportLayerSecurityTLS `json:"proxy_tls,omitempty" parquet:"proxy_tls,optional"`
+
+	// Proxy Traffic: The network traffic refers to the amount of data moving across a network, from proxy to remote server at a given point of time.
+	ProxyTraffic *NetworkTraffic `json:"proxy_traffic,omitempty" parquet:"proxy_traffic,optional"`
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the severity_id value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -152,30 +224,54 @@ func (v *HTTPActivity) ValidateObservables() error {
 }
 
 var HTTPActivityFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
 	{Name: "app_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "connection_info", Type: NetworkConnectionInformationStruct, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "dst_endpoint", Type: NetworkEndpointStruct, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
 	{Name: "file", Type: FileStruct, Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
 	{Name: "http_cookies", Type: arrow.ListOf(HTTPCookieStruct), Nullable: true},
 	{Name: "http_request", Type: HTTPRequestStruct, Nullable: true},
 	{Name: "http_response", Type: HTTPResponseStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
 	{Name: "ja4_fingerprint_list", Type: arrow.ListOf(JA4FingerprintStruct), Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
+	{Name: "proxy_connection_info", Type: NetworkConnectionInformationStruct, Nullable: true},
+	{Name: "proxy_endpoint", Type: NetworkProxyEndpointStruct, Nullable: true},
+	{Name: "proxy_http_request", Type: HTTPRequestStruct, Nullable: true},
+	{Name: "proxy_http_response", Type: HTTPResponseStruct, Nullable: true},
+	{Name: "proxy_tls", Type: TransportLayerSecurityTLSStruct, Nullable: true},
+	{Name: "proxy_traffic", Type: NetworkTrafficStruct, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "src_endpoint", Type: NetworkEndpointStruct, Nullable: true},

--- a/ocsf/v1_4_0/incident_finding.go
+++ b/ocsf/v1_4_0/incident_finding.go
@@ -10,11 +10,35 @@ import (
 
 type IncidentFinding struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the Incident activity.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The Incident activity name, as defined by the <code>activity_id</code>.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
+
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// Assignee: The details of the user assigned to an Incident.
+	Assignee *User `json:"assignee,omitempty" parquet:"assignee,optional"`
+
+	// Assignee Group: The details of the group assigned to an Incident.
+	AssigneeGroup *Group `json:"assignee_group,omitempty" parquet:"assignee_group,optional"`
+
+	// MITRE ATT&CK® Details: An array of <a target='_blank' href='https://attack.mitre.org'>MITRE ATT&CK®</a> objects describing the tactics, techniques & sub-techniques associated to the Incident.
+	Attacks []MITREATTCK `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Findings</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -28,17 +52,32 @@ type IncidentFinding struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
-
 	// Comment: Additional user supplied details for updating or closing the incident.
 	Comment *string `json:"comment,omitempty" parquet:"comment,optional"`
+
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
 
 	// Description: The short description of the Incident.
 	Desc *string `json:"desc,omitempty" parquet:"desc,optional"`
+
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -52,6 +91,27 @@ type IncidentFinding struct {
 	// Finding Information List: A list of <code>finding_info</code> objects associated to an incident.
 	FindingInfoList []FindingInformation `json:"finding_info_list" parquet:"finding_info_list,list"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Impact: The impact , normalized to the caption of the impact_id value. In the case of 'Other', it is defined by the event source.
+	Impact *string `json:"impact,omitempty" parquet:"impact,optional"`
+
+	// Impact ID: The normalized impact of the incident or finding. Per NIST, this is the magnitude of harm that can be expected to result from the consequences of unauthorized disclosure, modification, destruction, or loss of information or information system availability.
+	ImpactId *int32 `json:"impact_id,omitempty" parquet:"impact_id,optional"`
+
+	// Impact Score: The impact as an integer value of the finding, valid range 0-100.
+	ImpactScore *int32 `json:"impact_score,omitempty" parquet:"impact_score,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Suspected Breach: A determination based on analytics as to whether a potential breach was found.
+	IsSuspectedBreach *bool `json:"is_suspected_breach,omitempty" parquet:"is_suspected_breach,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
 
@@ -61,17 +121,38 @@ type IncidentFinding struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
+
+	// Priority: The priority, normalized to the caption of the priority_id value. In the case of 'Other', it is defined by the event source.
+	Priority *string `json:"priority,omitempty" parquet:"priority,optional"`
+
+	// Priority ID: The normalized priority. Priority identifies the relative importance of the incident or finding. It is a measurement of urgency.
+	PriorityId *int32 `json:"priority_id,omitempty" parquet:"priority_id,optional"`
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the severity_id value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
 
 	// Severity ID: <p>The normalized identifier of the event/finding severity.</p>The normalized severity is a measurement the effort and expense required to manage and resolve an event or incident. Smaller numerical values represent lower impact events, and larger numerical values represent higher impact events.
 	SeverityId int32 `json:"severity_id" parquet:"severity_id"`
+
+	// Source URL: A Url link used to access the original incident.
+	SrcUrl *string `json:"src_url,omitempty" parquet:"src_url,optional"`
 
 	// Start Time: The time of the least recent event included in the incident.
 	StartTime int64 `json:"start_time,omitempty" parquet:"start_time,timestamp_millis,timestamp(millisecond),optional"`
@@ -87,6 +168,9 @@ type IncidentFinding struct {
 
 	// Status ID: The normalized status identifier of the Incident.
 	StatusId int32 `json:"status_id" parquet:"status_id"`
+
+	// Ticket: The linked ticket in the ticketing system.
+	Ticket *Ticket `json:"ticket,omitempty" parquet:"ticket,optional"`
 
 	// Event Time: The normalized event occurrence time or the finding creation time.
 	Time int64 `json:"time" parquet:"time,timestamp_millis,timestamp(millisecond)"`
@@ -105,6 +189,12 @@ type IncidentFinding struct {
 
 	// Vendor Attributes: The Vendor Attributes object can be used to represent values of attributes populated by the Vendor/Finding Provider. It can help distinguish between the vendor-prodvided values and consumer-updated values, of key attributes like <code>severity_id</code>.<br>The original finding producer should not populate this object. It should be populated by consuming systems that support data mutability.
 	VendorAttributes *VendorAttributes `json:"vendor_attributes,omitempty" parquet:"vendor_attributes,optional"`
+
+	// Verdict: The verdict assigned to an Incident finding.
+	Verdict *string `json:"verdict,omitempty" parquet:"verdict,optional"`
+
+	// Verdict ID: The normalized verdict of an Incident.
+	VerdictId *int32 `json:"verdict_id,omitempty" parquet:"verdict_id,optional"`
 }
 
 func (v *IncidentFinding) Observable() (*int, string) {
@@ -131,38 +221,68 @@ func (v *IncidentFinding) ValidateObservables() error {
 }
 
 var IncidentFindingFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "assignee", Type: UserStruct, Nullable: true},
+	{Name: "assignee_group", Type: GroupStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
 	{Name: "comment", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "desc", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
 	{Name: "finding_info_list", Type: arrow.ListOf(FindingInformationStruct), Nullable: false},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "impact", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "impact_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "impact_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "is_suspected_breach", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
+	{Name: "priority", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "priority_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
+	{Name: "src_url", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "start_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "status", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "status_code", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "status_detail", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "status_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
+	{Name: "ticket", Type: TicketStruct, Nullable: true},
 	{Name: "time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: false},
 	{Name: "timezone_offset", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "type_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "type_uid", Type: arrow.PrimitiveTypes.Int64, Nullable: false},
 	{Name: "unmapped", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "vendor_attributes", Type: VendorAttributesStruct, Nullable: true},
+	{Name: "verdict", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "verdict_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 }
 
 var IncidentFindingStruct = arrow.StructOf(IncidentFindingFields...)

--- a/ocsf/v1_4_0/inventory_info.go
+++ b/ocsf/v1_4_0/inventory_info.go
@@ -10,11 +10,29 @@ import (
 
 type DeviceInventoryInfo struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
+
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® Details: An array of <a target='_blank' href='https://attack.mitre.org'>MITRE ATT&CK®</a> objects describing identified tactics, techniques & sub-techniques.
+	Attacks []MITREATTCK `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Discovery</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -28,14 +46,26 @@ type DeviceInventoryInfo struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
 
 	// Device: The device that is being discovered by an inventory process.
 	Device Device `json:"device" parquet:"device"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -46,6 +76,15 @@ type DeviceInventoryInfo struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
 
@@ -55,11 +94,23 @@ type DeviceInventoryInfo struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the severity_id value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -122,23 +173,40 @@ func (v *DeviceInventoryInfo) ValidateObservables() error {
 }
 
 var DeviceInventoryInfoFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "device", Type: DeviceStruct, Nullable: false},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "start_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},

--- a/ocsf/v1_4_0/job_query.go
+++ b/ocsf/v1_4_0/job_query.go
@@ -10,11 +10,29 @@ import (
 
 type JobQuery struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
+
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® Details: An array of <a target='_blank' href='https://attack.mitre.org'>MITRE ATT&CK®</a> objects describing identified tactics, techniques & sub-techniques.
+	Attacks []MITREATTCK `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Discovery</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -28,11 +46,26 @@ type JobQuery struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
+
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -43,8 +76,17 @@ type JobQuery struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
 	// Job: The job object that pertains to the event.
 	Job Job `json:"job" parquet:"job"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
 
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
@@ -55,8 +97,8 @@ type JobQuery struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Query Info: The search details associated with the query request.
 	QueryInfo *QueryInformation `json:"query_info,omitempty" parquet:"query_info,optional"`
@@ -69,6 +111,18 @@ type JobQuery struct {
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the severity_id value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -131,26 +185,44 @@ func (v *JobQuery) ValidateObservables() error {
 }
 
 var JobQueryFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
 	{Name: "job", Type: JobStruct, Nullable: false},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "query_info", Type: QueryInformationStruct, Nullable: true},
 	{Name: "query_result", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "query_result_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "start_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},

--- a/ocsf/v1_4_0/kernel_activity.go
+++ b/ocsf/v1_4_0/kernel_activity.go
@@ -10,6 +10,12 @@ import (
 
 type KernelActivity struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
@@ -18,6 +24,15 @@ type KernelActivity struct {
 
 	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
 	Actor Actor `json:"actor" parquet:"actor"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® Details: An array of <a target='_blank' href='https://attack.mitre.org'>MITRE ATT&CK®</a> objects describing identified tactics, techniques & sub-techniques.
+	Attacks []MITREATTCK `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>System Activity</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -31,14 +46,26 @@ type KernelActivity struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
 
 	// Device: An addressable device, computer system or host.
 	Device Device `json:"device" parquet:"device"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -49,8 +76,17 @@ type KernelActivity struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
 	// Kernel: The target kernel resource.
 	Kernel KernelResource `json:"kernel" parquet:"kernel"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
 
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
@@ -61,11 +97,23 @@ type KernelActivity struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the severity_id value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -128,25 +176,41 @@ func (v *KernelActivity) ValidateObservables() error {
 }
 
 var KernelActivityFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "actor", Type: ActorStruct, Nullable: false},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "device", Type: DeviceStruct, Nullable: false},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
 	{Name: "kernel", Type: KernelResourceStruct, Nullable: false},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "start_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},

--- a/ocsf/v1_4_0/kernel_extension_activity.go
+++ b/ocsf/v1_4_0/kernel_extension_activity.go
@@ -10,6 +10,12 @@ import (
 
 type KernelExtensionActivity struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
@@ -18,6 +24,15 @@ type KernelExtensionActivity struct {
 
 	// Actor: The actor process that loaded or unloaded the driver/extension.
 	Actor Actor `json:"actor" parquet:"actor"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® Details: An array of <a target='_blank' href='https://attack.mitre.org'>MITRE ATT&CK®</a> objects describing identified tactics, techniques & sub-techniques.
+	Attacks []MITREATTCK `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>System Activity</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -31,14 +46,26 @@ type KernelExtensionActivity struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
 
 	// Device: An addressable device, computer system or host.
 	Device Device `json:"device" parquet:"device"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Kernel Driver: The driver that was loaded/unloaded into the kernel
 	Driver KernelExtension `json:"driver" parquet:"driver"`
@@ -52,6 +79,15 @@ type KernelExtensionActivity struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
 
@@ -61,11 +97,23 @@ type KernelExtensionActivity struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the severity_id value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -128,25 +176,41 @@ func (v *KernelExtensionActivity) ValidateObservables() error {
 }
 
 var KernelExtensionActivityFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "actor", Type: ActorStruct, Nullable: false},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "device", Type: DeviceStruct, Nullable: false},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "driver", Type: KernelExtensionStruct, Nullable: false},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "start_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},

--- a/ocsf/v1_4_0/kernel_object_query.go
+++ b/ocsf/v1_4_0/kernel_object_query.go
@@ -10,11 +10,29 @@ import (
 
 type KernelObjectQuery struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
+
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® Details: An array of <a target='_blank' href='https://attack.mitre.org'>MITRE ATT&CK®</a> objects describing identified tactics, techniques & sub-techniques.
+	Attacks []MITREATTCK `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Discovery</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -28,11 +46,26 @@ type KernelObjectQuery struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
+
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -43,8 +76,17 @@ type KernelObjectQuery struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
 	// Kernel: The kernel object that pertains to the event.
 	Kernel KernelResource `json:"kernel" parquet:"kernel"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
 
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
@@ -55,8 +97,8 @@ type KernelObjectQuery struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Query Info: The search details associated with the query request.
 	QueryInfo *QueryInformation `json:"query_info,omitempty" parquet:"query_info,optional"`
@@ -69,6 +111,18 @@ type KernelObjectQuery struct {
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the severity_id value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -131,26 +185,44 @@ func (v *KernelObjectQuery) ValidateObservables() error {
 }
 
 var KernelObjectQueryFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
 	{Name: "kernel", Type: KernelResourceStruct, Nullable: false},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "query_info", Type: QueryInformationStruct, Nullable: true},
 	{Name: "query_result", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "query_result_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "start_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},

--- a/ocsf/v1_4_0/memory_activity.go
+++ b/ocsf/v1_4_0/memory_activity.go
@@ -10,6 +10,12 @@ import (
 
 type MemoryActivity struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
@@ -21,6 +27,15 @@ type MemoryActivity struct {
 
 	// Actual Permissions: The permissions that were granted to access memory.
 	ActualPermissions *int32 `json:"actual_permissions,omitempty" parquet:"actual_permissions,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® Details: An array of <a target='_blank' href='https://attack.mitre.org'>MITRE ATT&CK®</a> objects describing identified tactics, techniques & sub-techniques.
+	Attacks []MITREATTCK `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Base Address: The memory address that was access or requested.
 	BaseAddress *string `json:"base_address,omitempty" parquet:"base_address,optional"`
@@ -37,14 +52,26 @@ type MemoryActivity struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
 
 	// Device: An addressable device, computer system or host.
 	Device Device `json:"device" parquet:"device"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -55,6 +82,15 @@ type MemoryActivity struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
 
@@ -64,8 +100,8 @@ type MemoryActivity struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Process: The process that had memory allocated, read/written, or had other manipulation activities performed on it.
 	Process Process `json:"process" parquet:"process"`
@@ -75,6 +111,18 @@ type MemoryActivity struct {
 
 	// Requested Permissions: The permissions mask that was requested to access memory.
 	RequestedPermissions *int32 `json:"requested_permissions,omitempty" parquet:"requested_permissions,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the severity_id value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -140,28 +188,44 @@ func (v *MemoryActivity) ValidateObservables() error {
 }
 
 var MemoryActivityFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "actor", Type: ActorStruct, Nullable: false},
 	{Name: "actual_permissions", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "base_address", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "device", Type: DeviceStruct, Nullable: false},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "process", Type: ProcessStruct, Nullable: false},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "requested_permissions", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "size", Type: arrow.PrimitiveTypes.Int64, Nullable: true},

--- a/ocsf/v1_4_0/module_activity.go
+++ b/ocsf/v1_4_0/module_activity.go
@@ -10,6 +10,12 @@ import (
 
 type ModuleActivity struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
@@ -18,6 +24,15 @@ type ModuleActivity struct {
 
 	// Actor: The actor that loaded or unloaded the <code>module</code>.
 	Actor Actor `json:"actor" parquet:"actor"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® Details: An array of <a target='_blank' href='https://attack.mitre.org'>MITRE ATT&CK®</a> objects describing identified tactics, techniques & sub-techniques.
+	Attacks []MITREATTCK `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>System Activity</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -31,14 +46,26 @@ type ModuleActivity struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
 
 	// Device: An addressable device, computer system or host.
 	Device Device `json:"device" parquet:"device"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -48,6 +75,15 @@ type ModuleActivity struct {
 
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
+
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
 
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
@@ -61,11 +97,23 @@ type ModuleActivity struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the severity_id value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -128,25 +176,41 @@ func (v *ModuleActivity) ValidateObservables() error {
 }
 
 var ModuleActivityFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "actor", Type: ActorStruct, Nullable: false},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "device", Type: DeviceStruct, Nullable: false},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "module", Type: ModuleStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "start_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},

--- a/ocsf/v1_4_0/module_query.go
+++ b/ocsf/v1_4_0/module_query.go
@@ -10,11 +10,29 @@ import (
 
 type ModuleQuery struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
+
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® Details: An array of <a target='_blank' href='https://attack.mitre.org'>MITRE ATT&CK®</a> objects describing identified tactics, techniques & sub-techniques.
+	Attacks []MITREATTCK `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Discovery</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -28,11 +46,26 @@ type ModuleQuery struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
+
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -42,6 +75,15 @@ type ModuleQuery struct {
 
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
+
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
 
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
@@ -55,8 +97,8 @@ type ModuleQuery struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Process: The process that loaded the module.
 	Process Process `json:"process" parquet:"process"`
@@ -72,6 +114,18 @@ type ModuleQuery struct {
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the severity_id value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -134,27 +188,45 @@ func (v *ModuleQuery) ValidateObservables() error {
 }
 
 var ModuleQueryFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "module", Type: ModuleStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "process", Type: ProcessStruct, Nullable: false},
 	{Name: "query_info", Type: QueryInformationStruct, Nullable: true},
 	{Name: "query_result", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "query_result_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "start_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},

--- a/ocsf/v1_4_0/network_activity.go
+++ b/ocsf/v1_4_0/network_activity.go
@@ -10,14 +10,32 @@ import (
 
 type NetworkActivity struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
 
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
 	// Application Name: The name of the application associated with the event or object.
 	AppName *string `json:"app_name,omitempty" parquet:"app_name,optional"`
+
+	// MITRE ATT&CK® Details: An array of <a target='_blank' href='https://attack.mitre.org'>MITRE ATT&CK®</a> objects describing identified tactics, techniques & sub-techniques.
+	Attacks []MITREATTCK `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Network Activity</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -31,14 +49,29 @@ type NetworkActivity struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Connection Info: The network connection information.
 	ConnectionInfo *NetworkConnectionInformation `json:"connection_info,omitempty" parquet:"connection_info,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
+
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Destination Endpoint: The responder (server) in a network connection.
 	DstEndpoint *NetworkEndpoint `json:"dst_endpoint,omitempty" parquet:"dst_endpoint,optional"`
@@ -52,8 +85,17 @@ type NetworkActivity struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
 	// JA4+ Fingerprints: A list of the JA4+ network fingerprints.
 	Ja4FingerprintList []JA4Fingerprint `json:"ja4_fingerprint_list,omitempty" parquet:"ja4_fingerprint_list,list,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
 
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
@@ -64,11 +106,41 @@ type NetworkActivity struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
+
+	// Proxy Connection Info: The connection information from the proxy server to the remote server.
+	ProxyConnectionInfo *NetworkConnectionInformation `json:"proxy_connection_info,omitempty" parquet:"proxy_connection_info,optional"`
+
+	// Proxy Endpoint: The proxy (server) in a network connection.
+	ProxyEndpoint *NetworkProxyEndpoint `json:"proxy_endpoint,omitempty" parquet:"proxy_endpoint,optional"`
+
+	// Proxy HTTP Request: The HTTP Request from the proxy server to the remote server.
+	ProxyHttpRequest *HTTPRequest `json:"proxy_http_request,omitempty" parquet:"proxy_http_request,optional"`
+
+	// Proxy HTTP Response: The HTTP Response from the remote server to the proxy server.
+	ProxyHttpResponse *HTTPResponse `json:"proxy_http_response,omitempty" parquet:"proxy_http_response,optional"`
+
+	// Proxy TLS: The TLS protocol negotiated between the proxy server and the remote server.
+	ProxyTls *TransportLayerSecurityTLS `json:"proxy_tls,omitempty" parquet:"proxy_tls,optional"`
+
+	// Proxy Traffic: The network traffic refers to the amount of data moving across a network, from proxy to remote server at a given point of time.
+	ProxyTraffic *NetworkTraffic `json:"proxy_traffic,omitempty" parquet:"proxy_traffic,optional"`
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the severity_id value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -143,26 +215,50 @@ func (v *NetworkActivity) ValidateObservables() error {
 }
 
 var NetworkActivityFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
 	{Name: "app_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "connection_info", Type: NetworkConnectionInformationStruct, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "dst_endpoint", Type: NetworkEndpointStruct, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
 	{Name: "ja4_fingerprint_list", Type: arrow.ListOf(JA4FingerprintStruct), Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
+	{Name: "proxy_connection_info", Type: NetworkConnectionInformationStruct, Nullable: true},
+	{Name: "proxy_endpoint", Type: NetworkProxyEndpointStruct, Nullable: true},
+	{Name: "proxy_http_request", Type: HTTPRequestStruct, Nullable: true},
+	{Name: "proxy_http_response", Type: HTTPResponseStruct, Nullable: true},
+	{Name: "proxy_tls", Type: TransportLayerSecurityTLSStruct, Nullable: true},
+	{Name: "proxy_traffic", Type: NetworkTrafficStruct, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "src_endpoint", Type: NetworkEndpointStruct, Nullable: true},

--- a/ocsf/v1_4_0/network_connection_query.go
+++ b/ocsf/v1_4_0/network_connection_query.go
@@ -10,11 +10,29 @@ import (
 
 type NetworkConnectionQuery struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
+
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® Details: An array of <a target='_blank' href='https://attack.mitre.org'>MITRE ATT&CK®</a> objects describing identified tactics, techniques & sub-techniques.
+	Attacks []MITREATTCK `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Discovery</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -28,14 +46,29 @@ type NetworkConnectionQuery struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Connection Info: The network connection information.
 	ConnectionInfo NetworkConnectionInformation `json:"connection_info" parquet:"connection_info"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
+
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -46,6 +79,15 @@ type NetworkConnectionQuery struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
 
@@ -55,8 +97,8 @@ type NetworkConnectionQuery struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Process: The process that owns the socket.
 	Process Process `json:"process" parquet:"process"`
@@ -72,6 +114,18 @@ type NetworkConnectionQuery struct {
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the severity_id value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -140,27 +194,45 @@ func (v *NetworkConnectionQuery) ValidateObservables() error {
 }
 
 var NetworkConnectionQueryFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "connection_info", Type: NetworkConnectionInformationStruct, Nullable: false},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "process", Type: ProcessStruct, Nullable: false},
 	{Name: "query_info", Type: QueryInformationStruct, Nullable: true},
 	{Name: "query_result", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "query_result_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "start_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},

--- a/ocsf/v1_4_0/network_file_activity.go
+++ b/ocsf/v1_4_0/network_file_activity.go
@@ -10,6 +10,12 @@ import (
 
 type NetworkFileActivity struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
@@ -19,8 +25,17 @@ type NetworkFileActivity struct {
 	// Actor: The actor that performed the activity on the target file.
 	Actor Actor `json:"actor" parquet:"actor"`
 
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
 	// Application Name: The name of the application associated with the event or object.
 	AppName *string `json:"app_name,omitempty" parquet:"app_name,optional"`
+
+	// MITRE ATT&CK® Details: An array of <a target='_blank' href='https://attack.mitre.org'>MITRE ATT&CK®</a> objects describing identified tactics, techniques & sub-techniques.
+	Attacks []MITREATTCK `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Network Activity</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -34,14 +49,29 @@ type NetworkFileActivity struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Connection Info: The network connection information.
 	ConnectionInfo *NetworkConnectionInformation `json:"connection_info,omitempty" parquet:"connection_info,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
+
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Destination Endpoint: The endpoint that received the activity on the target file.
 	DstEndpoint *NetworkEndpoint `json:"dst_endpoint,omitempty" parquet:"dst_endpoint,optional"`
@@ -61,8 +91,17 @@ type NetworkFileActivity struct {
 	// File: The file that is the target of the activity.
 	File File `json:"file" parquet:"file"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
 	// JA4+ Fingerprints: A list of the JA4+ network fingerprints.
 	Ja4FingerprintList []JA4Fingerprint `json:"ja4_fingerprint_list,omitempty" parquet:"ja4_fingerprint_list,list,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
 
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
@@ -73,11 +112,41 @@ type NetworkFileActivity struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
+
+	// Proxy Connection Info: The connection information from the proxy server to the remote server.
+	ProxyConnectionInfo *NetworkConnectionInformation `json:"proxy_connection_info,omitempty" parquet:"proxy_connection_info,optional"`
+
+	// Proxy Endpoint: The proxy (server) in a network connection.
+	ProxyEndpoint *NetworkProxyEndpoint `json:"proxy_endpoint,omitempty" parquet:"proxy_endpoint,optional"`
+
+	// Proxy HTTP Request: The HTTP Request from the proxy server to the remote server.
+	ProxyHttpRequest *HTTPRequest `json:"proxy_http_request,omitempty" parquet:"proxy_http_request,optional"`
+
+	// Proxy HTTP Response: The HTTP Response from the remote server to the proxy server.
+	ProxyHttpResponse *HTTPResponse `json:"proxy_http_response,omitempty" parquet:"proxy_http_response,optional"`
+
+	// Proxy TLS: The TLS protocol negotiated between the proxy server and the remote server.
+	ProxyTls *TransportLayerSecurityTLS `json:"proxy_tls,omitempty" parquet:"proxy_tls,optional"`
+
+	// Proxy Traffic: The network traffic refers to the amount of data moving across a network, from proxy to remote server at a given point of time.
+	ProxyTraffic *NetworkTraffic `json:"proxy_traffic,omitempty" parquet:"proxy_traffic,optional"`
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the severity_id value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -149,29 +218,52 @@ func (v *NetworkFileActivity) ValidateObservables() error {
 }
 
 var NetworkFileActivityFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "actor", Type: ActorStruct, Nullable: false},
+	{Name: "api", Type: APIStruct, Nullable: true},
 	{Name: "app_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "connection_info", Type: NetworkConnectionInformationStruct, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "dst_endpoint", Type: NetworkEndpointStruct, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
 	{Name: "expiration_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "file", Type: FileStruct, Nullable: false},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
 	{Name: "ja4_fingerprint_list", Type: arrow.ListOf(JA4FingerprintStruct), Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
+	{Name: "proxy_connection_info", Type: NetworkConnectionInformationStruct, Nullable: true},
+	{Name: "proxy_endpoint", Type: NetworkProxyEndpointStruct, Nullable: true},
+	{Name: "proxy_http_request", Type: HTTPRequestStruct, Nullable: true},
+	{Name: "proxy_http_response", Type: HTTPResponseStruct, Nullable: true},
+	{Name: "proxy_tls", Type: TransportLayerSecurityTLSStruct, Nullable: true},
+	{Name: "proxy_traffic", Type: NetworkTrafficStruct, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "src_endpoint", Type: NetworkEndpointStruct, Nullable: false},

--- a/ocsf/v1_4_0/network_remediation_activity.go
+++ b/ocsf/v1_4_0/network_remediation_activity.go
@@ -10,11 +10,29 @@ import (
 
 type NetworkRemediationActivity struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: Matches the MITRE D3FEND™ Tactic. Note: the Model and Detect Tactics are not supported as remediations by the OCSF Remediation event class.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
+
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® Details: An array of <a target='_blank' href='https://attack.mitre.org'>MITRE ATT&CK®</a> objects describing identified tactics, techniques & sub-techniques.
+	Attacks []MITREATTCK `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Remediation</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -28,11 +46,17 @@ type NetworkRemediationActivity struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
-
 	// Command UID: The unique identifier of the remediation command that pertains to this event.
 	CommandUid string `json:"command_uid" parquet:"command_uid"`
+
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Connection Info: The network connection that pertains to the remediation event.
 	ConnectionInfo NetworkConnectionInformation `json:"connection_info" parquet:"connection_info"`
@@ -43,6 +67,15 @@ type NetworkRemediationActivity struct {
 	// Countermeasures: The MITRE DEFEND™ Matrix Countermeasures associated with a remediation.
 	Countermeasures []MITRED3FEND `json:"countermeasures,omitempty" parquet:"countermeasures,list,optional"`
 
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
+
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
 
@@ -51,6 +84,15 @@ type NetworkRemediationActivity struct {
 
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
+
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
 
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
@@ -61,14 +103,26 @@ type NetworkRemediationActivity struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
 
 	// Remediation Guidance: Describes the recommended remediation steps to address identified issue(s).
 	Remediation *Remediation `json:"remediation,omitempty" parquet:"remediation,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Scan: The remediation scan that pertains to this event.
 	Scan *Scan `json:"scan,omitempty" parquet:"scan,optional"`
@@ -134,26 +188,44 @@ func (v *NetworkRemediationActivity) ValidateObservables() error {
 }
 
 var NetworkRemediationActivityFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
 	{Name: "command_uid", Type: arrow.BinaryTypes.String, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "connection_info", Type: NetworkConnectionInformationStruct, Nullable: false},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "countermeasures", Type: arrow.ListOf(MITRED3FENDStruct), Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "remediation", Type: RemediationStruct, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "scan", Type: ScanStruct, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},

--- a/ocsf/v1_4_0/networks_query.go
+++ b/ocsf/v1_4_0/networks_query.go
@@ -10,11 +10,29 @@ import (
 
 type NetworksQuery struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
+
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® Details: An array of <a target='_blank' href='https://attack.mitre.org'>MITRE ATT&CK®</a> objects describing identified tactics, techniques & sub-techniques.
+	Attacks []MITREATTCK `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Discovery</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -28,11 +46,26 @@ type NetworksQuery struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
+
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -42,6 +75,15 @@ type NetworksQuery struct {
 
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
+
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
 
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
@@ -55,8 +97,8 @@ type NetworksQuery struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Query Info: The search details associated with the query request.
 	QueryInfo *QueryInformation `json:"query_info,omitempty" parquet:"query_info,optional"`
@@ -69,6 +111,18 @@ type NetworksQuery struct {
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the severity_id value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -131,26 +185,44 @@ func (v *NetworksQuery) ValidateObservables() error {
 }
 
 var NetworksQueryFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "network_interfaces", Type: arrow.ListOf(NetworkInterfaceStruct), Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "query_info", Type: QueryInformationStruct, Nullable: true},
 	{Name: "query_result", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "query_result_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "start_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},

--- a/ocsf/v1_4_0/ntp_activity.go
+++ b/ocsf/v1_4_0/ntp_activity.go
@@ -10,14 +10,32 @@ import (
 
 type NTPActivity struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
 
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
 	// Application Name: The name of the application associated with the event or object.
 	AppName *string `json:"app_name,omitempty" parquet:"app_name,optional"`
+
+	// MITRE ATT&CK® Details: An array of <a target='_blank' href='https://attack.mitre.org'>MITRE ATT&CK®</a> objects describing identified tactics, techniques & sub-techniques.
+	Attacks []MITREATTCK `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Network Activity</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -31,8 +49,14 @@ type NTPActivity struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Connection Info: The network connection information.
 	ConnectionInfo *NetworkConnectionInformation `json:"connection_info,omitempty" parquet:"connection_info,optional"`
@@ -43,8 +67,17 @@ type NTPActivity struct {
 	// Root Delay: The total round-trip delay to the reference clock in milliseconds.
 	Delay *int32 `json:"delay,omitempty" parquet:"delay,optional"`
 
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
 	// Root Dispersion: The dispersion in the NTP protocol is the estimated time error or uncertainty relative to the reference clock in milliseconds.
 	Dispersion *int32 `json:"dispersion,omitempty" parquet:"dispersion,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Destination Endpoint: The responder (server) in a network connection.
 	DstEndpoint *NetworkEndpoint `json:"dst_endpoint,omitempty" parquet:"dst_endpoint,optional"`
@@ -58,8 +91,17 @@ type NTPActivity struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
 	// JA4+ Fingerprints: A list of the JA4+ network fingerprints.
 	Ja4FingerprintList []JA4Fingerprint `json:"ja4_fingerprint_list,omitempty" parquet:"ja4_fingerprint_list,list,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
 
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
@@ -70,14 +112,44 @@ type NTPActivity struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Precision: The NTP precision quantifies a clock's accuracy and stability in log2 seconds, as defined in RFC-5905.
 	Precision *int32 `json:"precision,omitempty" parquet:"precision,optional"`
 
+	// Proxy Connection Info: The connection information from the proxy server to the remote server.
+	ProxyConnectionInfo *NetworkConnectionInformation `json:"proxy_connection_info,omitempty" parquet:"proxy_connection_info,optional"`
+
+	// Proxy Endpoint: The proxy (server) in a network connection.
+	ProxyEndpoint *NetworkProxyEndpoint `json:"proxy_endpoint,omitempty" parquet:"proxy_endpoint,optional"`
+
+	// Proxy HTTP Request: The HTTP Request from the proxy server to the remote server.
+	ProxyHttpRequest *HTTPRequest `json:"proxy_http_request,omitempty" parquet:"proxy_http_request,optional"`
+
+	// Proxy HTTP Response: The HTTP Response from the remote server to the proxy server.
+	ProxyHttpResponse *HTTPResponse `json:"proxy_http_response,omitempty" parquet:"proxy_http_response,optional"`
+
+	// Proxy TLS: The TLS protocol negotiated between the proxy server and the remote server.
+	ProxyTls *TransportLayerSecurityTLS `json:"proxy_tls,omitempty" parquet:"proxy_tls,optional"`
+
+	// Proxy Traffic: The network traffic refers to the amount of data moving across a network, from proxy to remote server at a given point of time.
+	ProxyTraffic *NetworkTraffic `json:"proxy_traffic,omitempty" parquet:"proxy_traffic,optional"`
+
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the severity_id value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -158,29 +230,53 @@ func (v *NTPActivity) ValidateObservables() error {
 }
 
 var NTPActivityFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
 	{Name: "app_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "connection_info", Type: NetworkConnectionInformationStruct, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "delay", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
 	{Name: "dispersion", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "dst_endpoint", Type: NetworkEndpointStruct, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
 	{Name: "ja4_fingerprint_list", Type: arrow.ListOf(JA4FingerprintStruct), Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "precision", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "proxy_connection_info", Type: NetworkConnectionInformationStruct, Nullable: true},
+	{Name: "proxy_endpoint", Type: NetworkProxyEndpointStruct, Nullable: true},
+	{Name: "proxy_http_request", Type: HTTPRequestStruct, Nullable: true},
+	{Name: "proxy_http_response", Type: HTTPResponseStruct, Nullable: true},
+	{Name: "proxy_tls", Type: TransportLayerSecurityTLSStruct, Nullable: true},
+	{Name: "proxy_traffic", Type: NetworkTrafficStruct, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "src_endpoint", Type: NetworkEndpointStruct, Nullable: true},

--- a/ocsf/v1_4_0/osint_inventory_info.go
+++ b/ocsf/v1_4_0/osint_inventory_info.go
@@ -10,11 +10,29 @@ import (
 
 type OSINTInventoryInfo struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
+
+	// Actor: The actor describes the process that was the source of the inventory activity. In the case of OSINT inventory data, that could be a particular process or script that is run to scrape the OSINT or threat intelligence data. For example, it could be a Python process that runs to pull data from a MISP or Shodan API.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® Details: An array of <a target='_blank' href='https://attack.mitre.org'>MITRE ATT&CK®</a> objects describing identified tactics, techniques & sub-techniques.
+	Attacks []MITREATTCK `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Discovery</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -28,11 +46,26 @@ type OSINTInventoryInfo struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
+
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -43,6 +76,15 @@ type OSINTInventoryInfo struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
 
@@ -52,11 +94,23 @@ type OSINTInventoryInfo struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT that is being discovered by an inventory process.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the severity_id value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -119,22 +173,40 @@ func (v *OSINTInventoryInfo) ValidateObservables() error {
 }
 
 var OSINTInventoryInfoFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "start_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},

--- a/ocsf/v1_4_0/patch_state.go
+++ b/ocsf/v1_4_0/patch_state.go
@@ -10,11 +10,29 @@ import (
 
 type OperatingSystemPatchState struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
+
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® Details: An array of <a target='_blank' href='https://attack.mitre.org'>MITRE ATT&CK®</a> objects describing identified tactics, techniques & sub-techniques.
+	Attacks []MITREATTCK `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Discovery</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -28,14 +46,26 @@ type OperatingSystemPatchState struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
 
 	// Device: An addressable device, computer system or host.
 	Device Device `json:"device" parquet:"device"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -46,8 +76,17 @@ type OperatingSystemPatchState struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
 	// Knowledgebase Articles: A list of KB articles or patches related to an endpoint. A KB Article contains metadata that describes the patch or an update.
 	KbArticleList []KBArticle `json:"kb_article_list,omitempty" parquet:"kb_article_list,list,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
 
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
@@ -58,11 +97,23 @@ type OperatingSystemPatchState struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the severity_id value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -125,24 +176,41 @@ func (v *OperatingSystemPatchState) ValidateObservables() error {
 }
 
 var OperatingSystemPatchStateFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "device", Type: DeviceStruct, Nullable: false},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
 	{Name: "kb_article_list", Type: arrow.ListOf(KBArticleStruct), Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "start_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},

--- a/ocsf/v1_4_0/peripheral_device_query.go
+++ b/ocsf/v1_4_0/peripheral_device_query.go
@@ -10,11 +10,29 @@ import (
 
 type PeripheralDeviceQuery struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
+
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® Details: An array of <a target='_blank' href='https://attack.mitre.org'>MITRE ATT&CK®</a> objects describing identified tactics, techniques & sub-techniques.
+	Attacks []MITREATTCK `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Discovery</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -28,11 +46,26 @@ type PeripheralDeviceQuery struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
+
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -43,6 +76,15 @@ type PeripheralDeviceQuery struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
 
@@ -52,11 +94,11 @@ type PeripheralDeviceQuery struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
-
 	// Peripheral Device: The peripheral device that triggered the event.
 	PeripheralDevice PeripheralDevice `json:"peripheral_device" parquet:"peripheral_device"`
+
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Query Info: The search details associated with the query request.
 	QueryInfo *QueryInformation `json:"query_info,omitempty" parquet:"query_info,optional"`
@@ -69,6 +111,18 @@ type PeripheralDeviceQuery struct {
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the severity_id value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -131,26 +185,44 @@ func (v *PeripheralDeviceQuery) ValidateObservables() error {
 }
 
 var PeripheralDeviceQueryFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
 	{Name: "peripheral_device", Type: PeripheralDeviceStruct, Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "query_info", Type: QueryInformationStruct, Nullable: true},
 	{Name: "query_result", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "query_result_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "start_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},

--- a/ocsf/v1_4_0/prefetch_query.go
+++ b/ocsf/v1_4_0/prefetch_query.go
@@ -10,11 +10,29 @@ import (
 
 type PrefetchQuery struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
+
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® Details: An array of <a target='_blank' href='https://attack.mitre.org'>MITRE ATT&CK®</a> objects describing identified tactics, techniques & sub-techniques.
+	Attacks []MITREATTCK `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Discovery</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -28,11 +46,26 @@ type PrefetchQuery struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
+
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -43,8 +76,17 @@ type PrefetchQuery struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
 	// Last Run: The prefetch file last run time.
 	LastRunTime int64 `json:"last_run_time,omitempty" parquet:"last_run_time,timestamp_millis,timestamp(millisecond),optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
 
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
@@ -58,8 +100,8 @@ type PrefetchQuery struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Query Info: The search details associated with the query request.
 	QueryInfo *QueryInformation `json:"query_info,omitempty" parquet:"query_info,optional"`
@@ -72,6 +114,18 @@ type PrefetchQuery struct {
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Run Count: The prefetch file run count.
 	RunCount *int32 `json:"run_count,omitempty" parquet:"run_count,optional"`
@@ -137,27 +191,45 @@ func (v *PrefetchQuery) ValidateObservables() error {
 }
 
 var PrefetchQueryFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
 	{Name: "last_run_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "name", Type: arrow.BinaryTypes.String, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "query_info", Type: QueryInformationStruct, Nullable: true},
 	{Name: "query_result", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "query_result_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "run_count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},

--- a/ocsf/v1_4_0/process_activity.go
+++ b/ocsf/v1_4_0/process_activity.go
@@ -10,6 +10,12 @@ import (
 
 type ProcessActivity struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
@@ -21,6 +27,15 @@ type ProcessActivity struct {
 
 	// Actual Permissions: The permissions that were granted to the process in a platform-native format.
 	ActualPermissions *int32 `json:"actual_permissions,omitempty" parquet:"actual_permissions,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® Details: An array of <a target='_blank' href='https://attack.mitre.org'>MITRE ATT&CK®</a> objects describing identified tactics, techniques & sub-techniques.
+	Attacks []MITREATTCK `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>System Activity</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -34,14 +49,26 @@ type ProcessActivity struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
 
 	// Device: An addressable device, computer system or host.
 	Device Device `json:"device" parquet:"device"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -55,11 +82,20 @@ type ProcessActivity struct {
 	// Exit Code: The exit code reported by a process when it terminates. The convention is that zero indicates success and any non-zero exit code indicates that some error occurred.
 	ExitCode *int32 `json:"exit_code,omitempty" parquet:"exit_code,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
 	// Injection Type: The process injection method, normalized to the caption of the injection_type_id value. In the case of 'Other', it is defined by the event source.
 	InjectionType *string `json:"injection_type,omitempty" parquet:"injection_type,optional"`
 
 	// Injection Type ID: The normalized identifier of the process injection method.
 	InjectionTypeId *int32 `json:"injection_type_id,omitempty" parquet:"injection_type_id,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
 
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
@@ -73,8 +109,8 @@ type ProcessActivity struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Process: The process that was launched, injected into, opened, or terminated.
 	Process Process `json:"process" parquet:"process"`
@@ -84,6 +120,18 @@ type ProcessActivity struct {
 
 	// Requested Permissions: The permissions mask that was requested by the process.
 	RequestedPermissions *int32 `json:"requested_permissions,omitempty" parquet:"requested_permissions,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the severity_id value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -146,31 +194,47 @@ func (v *ProcessActivity) ValidateObservables() error {
 }
 
 var ProcessActivityFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "actor", Type: ActorStruct, Nullable: false},
 	{Name: "actual_permissions", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "device", Type: DeviceStruct, Nullable: false},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
 	{Name: "exit_code", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
 	{Name: "injection_type", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "injection_type_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "module", Type: ModuleStruct, Nullable: true},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "process", Type: ProcessStruct, Nullable: false},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "requested_permissions", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "start_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},

--- a/ocsf/v1_4_0/process_query.go
+++ b/ocsf/v1_4_0/process_query.go
@@ -10,11 +10,29 @@ import (
 
 type ProcessQuery struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
+
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® Details: An array of <a target='_blank' href='https://attack.mitre.org'>MITRE ATT&CK®</a> objects describing identified tactics, techniques & sub-techniques.
+	Attacks []MITREATTCK `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Discovery</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -28,11 +46,26 @@ type ProcessQuery struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
+
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -43,6 +76,15 @@ type ProcessQuery struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
 
@@ -52,8 +94,8 @@ type ProcessQuery struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Process: The process object.
 	Process Process `json:"process" parquet:"process"`
@@ -69,6 +111,18 @@ type ProcessQuery struct {
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the severity_id value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -131,26 +185,44 @@ func (v *ProcessQuery) ValidateObservables() error {
 }
 
 var ProcessQueryFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "process", Type: ProcessStruct, Nullable: false},
 	{Name: "query_info", Type: QueryInformationStruct, Nullable: true},
 	{Name: "query_result", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "query_result_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "start_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},

--- a/ocsf/v1_4_0/process_remediation_activity.go
+++ b/ocsf/v1_4_0/process_remediation_activity.go
@@ -10,11 +10,29 @@ import (
 
 type ProcessRemediationActivity struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: Matches the MITRE D3FEND™ Tactic. Note: the Model and Detect Tactics are not supported as remediations by the OCSF Remediation event class.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
+
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® Details: An array of <a target='_blank' href='https://attack.mitre.org'>MITRE ATT&CK®</a> objects describing identified tactics, techniques & sub-techniques.
+	Attacks []MITREATTCK `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Remediation</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -28,17 +46,32 @@ type ProcessRemediationActivity struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
-
 	// Command UID: The unique identifier of the remediation command that pertains to this event.
 	CommandUid string `json:"command_uid" parquet:"command_uid"`
+
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
 
 	// Countermeasures: The MITRE DEFEND™ Matrix Countermeasures associated with a remediation.
 	Countermeasures []MITRED3FEND `json:"countermeasures,omitempty" parquet:"countermeasures,list,optional"`
+
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -49,6 +82,15 @@ type ProcessRemediationActivity struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
 
@@ -58,8 +100,8 @@ type ProcessRemediationActivity struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Process: The process that pertains to the remediation event.
 	Process Process `json:"process" parquet:"process"`
@@ -69,6 +111,18 @@ type ProcessRemediationActivity struct {
 
 	// Remediation Guidance: Describes the recommended remediation steps to address identified issue(s).
 	Remediation *Remediation `json:"remediation,omitempty" parquet:"remediation,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Scan: The remediation scan that pertains to this event.
 	Scan *Scan `json:"scan,omitempty" parquet:"scan,optional"`
@@ -134,26 +188,44 @@ func (v *ProcessRemediationActivity) ValidateObservables() error {
 }
 
 var ProcessRemediationActivityFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
 	{Name: "command_uid", Type: arrow.BinaryTypes.String, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "countermeasures", Type: arrow.ListOf(MITRED3FENDStruct), Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "process", Type: ProcessStruct, Nullable: false},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "remediation", Type: RemediationStruct, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "scan", Type: ScanStruct, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},

--- a/ocsf/v1_4_0/rdp_activity.go
+++ b/ocsf/v1_4_0/rdp_activity.go
@@ -10,14 +10,32 @@ import (
 
 type RDPActivity struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
 
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
 	// Application Name: The name of the application associated with the event or object.
 	AppName *string `json:"app_name,omitempty" parquet:"app_name,optional"`
+
+	// MITRE ATT&CK® Details: An array of <a target='_blank' href='https://attack.mitre.org'>MITRE ATT&CK®</a> objects describing identified tactics, techniques & sub-techniques.
+	Attacks []MITREATTCK `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Capabilities: A list of RDP capabilities.
 	Capabilities []string `json:"capabilities,omitempty" parquet:"capabilities,list,optional"`
@@ -37,14 +55,29 @@ type RDPActivity struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Connection Info: The network connection information.
 	ConnectionInfo *NetworkConnectionInformation `json:"connection_info,omitempty" parquet:"connection_info,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
+
+	// Device: The device instigating the RDP connection.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Destination Endpoint: The responder (server) in a network connection.
 	DstEndpoint *NetworkEndpoint `json:"dst_endpoint,omitempty" parquet:"dst_endpoint,optional"`
@@ -61,14 +94,23 @@ type RDPActivity struct {
 	// File: The file that is the target of the RDP activity.
 	File *File `json:"file,omitempty" parquet:"file,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
 	// Identifier Cookie: The client identifier cookie during client/server exchange.
 	IdentifierCookie *string `json:"identifier_cookie,omitempty" parquet:"identifier_cookie,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
 
 	// JA4+ Fingerprints: A list of the JA4+ network fingerprints.
 	Ja4FingerprintList []JA4Fingerprint `json:"ja4_fingerprint_list,omitempty" parquet:"ja4_fingerprint_list,list,optional"`
 
 	// Keyboard Information: The keyboard detailed information.
 	KeyboardInfo *KeyboardInformation `json:"keyboard_info,omitempty" parquet:"keyboard_info,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
 
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
@@ -79,11 +121,29 @@ type RDPActivity struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// RDP Version: The Remote Desktop Protocol version.
 	ProtocolVer *string `json:"protocol_ver,omitempty" parquet:"protocol_ver,optional"`
+
+	// Proxy Connection Info: The connection information from the proxy server to the remote server.
+	ProxyConnectionInfo *NetworkConnectionInformation `json:"proxy_connection_info,omitempty" parquet:"proxy_connection_info,optional"`
+
+	// Proxy Endpoint: The proxy (server) in a network connection.
+	ProxyEndpoint *NetworkProxyEndpoint `json:"proxy_endpoint,omitempty" parquet:"proxy_endpoint,optional"`
+
+	// Proxy HTTP Request: The HTTP Request from the proxy server to the remote server.
+	ProxyHttpRequest *HTTPRequest `json:"proxy_http_request,omitempty" parquet:"proxy_http_request,optional"`
+
+	// Proxy HTTP Response: The HTTP Response from the remote server to the proxy server.
+	ProxyHttpResponse *HTTPResponse `json:"proxy_http_response,omitempty" parquet:"proxy_http_response,optional"`
+
+	// Proxy TLS: The TLS protocol negotiated between the proxy server and the remote server.
+	ProxyTls *TransportLayerSecurityTLS `json:"proxy_tls,omitempty" parquet:"proxy_tls,optional"`
+
+	// Proxy Traffic: The network traffic refers to the amount of data moving across a network, from proxy to remote server at a given point of time.
+	ProxyTraffic *NetworkTraffic `json:"proxy_traffic,omitempty" parquet:"proxy_traffic,optional"`
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
@@ -96,6 +156,18 @@ type RDPActivity struct {
 
 	// API Response Details: The server response in an RDP network connection.
 	Response *ResponseElements `json:"response,omitempty" parquet:"response,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the severity_id value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -167,35 +239,59 @@ func (v *RDPActivity) ValidateObservables() error {
 }
 
 var RDPActivityFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
 	{Name: "app_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "capabilities", Type: arrow.ListOf(arrow.BinaryTypes.String), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "certificate_chain", Type: arrow.ListOf(arrow.BinaryTypes.String), Nullable: true},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "connection_info", Type: NetworkConnectionInformationStruct, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "dst_endpoint", Type: NetworkEndpointStruct, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
 	{Name: "file", Type: FileStruct, Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
 	{Name: "identifier_cookie", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
 	{Name: "ja4_fingerprint_list", Type: arrow.ListOf(JA4FingerprintStruct), Nullable: true},
 	{Name: "keyboard_info", Type: KeyboardInformationStruct, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "protocol_ver", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "proxy_connection_info", Type: NetworkConnectionInformationStruct, Nullable: true},
+	{Name: "proxy_endpoint", Type: NetworkProxyEndpointStruct, Nullable: true},
+	{Name: "proxy_http_request", Type: HTTPRequestStruct, Nullable: true},
+	{Name: "proxy_http_response", Type: HTTPResponseStruct, Nullable: true},
+	{Name: "proxy_tls", Type: TransportLayerSecurityTLSStruct, Nullable: true},
+	{Name: "proxy_traffic", Type: NetworkTrafficStruct, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "remote_display", Type: DisplayStruct, Nullable: true},
 	{Name: "request", Type: RequestElementsStruct, Nullable: true},
 	{Name: "response", Type: ResponseElementsStruct, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "src_endpoint", Type: NetworkEndpointStruct, Nullable: true},

--- a/ocsf/v1_4_0/registry_key_activity.go
+++ b/ocsf/v1_4_0/registry_key_activity.go
@@ -13,6 +13,12 @@ type RegistryKeyActivity struct {
 	// Access Mask: The access mask in a platform-native format.
 	AccessMask *int32 `json:"access_mask,omitempty" parquet:"access_mask,optional"`
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
@@ -21,6 +27,15 @@ type RegistryKeyActivity struct {
 
 	// Actor: The actor that performed the activity on the <code>reg_key</code> object.
 	Actor Actor `json:"actor" parquet:"actor"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® Details: An array of <a target='_blank' href='https://attack.mitre.org'>MITRE ATT&CK®</a> objects describing identified tactics, techniques & sub-techniques.
+	Attacks []MITREATTCK `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>System Activity</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -34,8 +49,14 @@ type RegistryKeyActivity struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
@@ -46,6 +67,12 @@ type RegistryKeyActivity struct {
 	// Device: An addressable device, computer system or host.
 	Device Device `json:"device" parquet:"device"`
 
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
+
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
 
@@ -54,6 +81,15 @@ type RegistryKeyActivity struct {
 
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
+
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
 
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
@@ -67,8 +103,8 @@ type RegistryKeyActivity struct {
 	// Open Mask: The Windows options needed to open a registry key.
 	OpenMask *int32 `json:"open_mask,omitempty" parquet:"open_mask,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Previous Registry Key: The registry key before the mutation
 	PrevRegKey *RegistryKey `json:"prev_reg_key,omitempty" parquet:"prev_reg_key,optional"`
@@ -78,6 +114,18 @@ type RegistryKeyActivity struct {
 
 	// Registry Key: The registry key.
 	RegKey RegistryKey `json:"reg_key" parquet:"reg_key"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the severity_id value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -141,28 +189,44 @@ func (v *RegistryKeyActivity) ValidateObservables() error {
 
 var RegistryKeyActivityFields = []arrow.Field{
 	{Name: "access_mask", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "actor", Type: ActorStruct, Nullable: false},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "create_mask", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "device", Type: DeviceStruct, Nullable: false},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
 	{Name: "open_mask", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "prev_reg_key", Type: RegistryKeyStruct, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "reg_key", Type: RegistryKeyStruct, Nullable: false},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "start_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},

--- a/ocsf/v1_4_0/registry_key_query.go
+++ b/ocsf/v1_4_0/registry_key_query.go
@@ -10,11 +10,29 @@ import (
 
 type RegistryKeyQuery struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
+
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® Details: An array of <a target='_blank' href='https://attack.mitre.org'>MITRE ATT&CK®</a> objects describing identified tactics, techniques & sub-techniques.
+	Attacks []MITREATTCK `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Discovery</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -28,11 +46,26 @@ type RegistryKeyQuery struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
+
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -43,6 +76,15 @@ type RegistryKeyQuery struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
 
@@ -52,8 +94,8 @@ type RegistryKeyQuery struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Query Info: The search details associated with the query request.
 	QueryInfo *QueryInformation `json:"query_info,omitempty" parquet:"query_info,optional"`
@@ -69,6 +111,18 @@ type RegistryKeyQuery struct {
 
 	// Registry Key: The registry key that pertains to the event.
 	RegKey RegistryKey `json:"reg_key" parquet:"reg_key"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the severity_id value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -131,26 +185,44 @@ func (v *RegistryKeyQuery) ValidateObservables() error {
 }
 
 var RegistryKeyQueryFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "query_info", Type: QueryInformationStruct, Nullable: true},
 	{Name: "query_result", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "query_result_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "reg_key", Type: RegistryKeyStruct, Nullable: false},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "start_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},

--- a/ocsf/v1_4_0/registry_value_activity.go
+++ b/ocsf/v1_4_0/registry_value_activity.go
@@ -10,6 +10,12 @@ import (
 
 type RegistryValueActivity struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
@@ -18,6 +24,15 @@ type RegistryValueActivity struct {
 
 	// Actor: The actor that performed the activity on the <code>reg_value</code> object.
 	Actor Actor `json:"actor" parquet:"actor"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® Details: An array of <a target='_blank' href='https://attack.mitre.org'>MITRE ATT&CK®</a> objects describing identified tactics, techniques & sub-techniques.
+	Attacks []MITREATTCK `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>System Activity</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -31,14 +46,26 @@ type RegistryValueActivity struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
 
 	// Device: An addressable device, computer system or host.
 	Device Device `json:"device" parquet:"device"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -49,6 +76,15 @@ type RegistryValueActivity struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
 
@@ -58,8 +94,8 @@ type RegistryValueActivity struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Previous Registry Value: The registry value before the mutation
 	PrevRegValue *RegistryValue `json:"prev_reg_value,omitempty" parquet:"prev_reg_value,optional"`
@@ -69,6 +105,18 @@ type RegistryValueActivity struct {
 
 	// Registry Value: The registry value.
 	RegValue RegistryValue `json:"reg_value" parquet:"reg_value"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the severity_id value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -131,26 +179,42 @@ func (v *RegistryValueActivity) ValidateObservables() error {
 }
 
 var RegistryValueActivityFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "actor", Type: ActorStruct, Nullable: false},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "device", Type: DeviceStruct, Nullable: false},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "prev_reg_value", Type: RegistryValueStruct, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "reg_value", Type: RegistryValueStruct, Nullable: false},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "start_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},

--- a/ocsf/v1_4_0/registry_value_query.go
+++ b/ocsf/v1_4_0/registry_value_query.go
@@ -10,11 +10,29 @@ import (
 
 type RegistryValueQuery struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
+
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® Details: An array of <a target='_blank' href='https://attack.mitre.org'>MITRE ATT&CK®</a> objects describing identified tactics, techniques & sub-techniques.
+	Attacks []MITREATTCK `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Discovery</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -28,11 +46,26 @@ type RegistryValueQuery struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
+
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -43,6 +76,15 @@ type RegistryValueQuery struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
 
@@ -52,8 +94,8 @@ type RegistryValueQuery struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Query Info: The search details associated with the query request.
 	QueryInfo *QueryInformation `json:"query_info,omitempty" parquet:"query_info,optional"`
@@ -69,6 +111,18 @@ type RegistryValueQuery struct {
 
 	// Registry Value: The registry value that pertains to the event.
 	RegValue RegistryValue `json:"reg_value" parquet:"reg_value"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the severity_id value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -131,26 +185,44 @@ func (v *RegistryValueQuery) ValidateObservables() error {
 }
 
 var RegistryValueQueryFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "query_info", Type: QueryInformationStruct, Nullable: true},
 	{Name: "query_result", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "query_result_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "reg_value", Type: RegistryValueStruct, Nullable: false},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "start_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},

--- a/ocsf/v1_4_0/remediation_activity.go
+++ b/ocsf/v1_4_0/remediation_activity.go
@@ -10,11 +10,29 @@ import (
 
 type RemediationActivity struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: Matches the MITRE D3FEND™ Tactic. Note: the Model and Detect Tactics are not supported as remediations by the OCSF Remediation event class.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
+
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® Details: An array of <a target='_blank' href='https://attack.mitre.org'>MITRE ATT&CK®</a> objects describing identified tactics, techniques & sub-techniques.
+	Attacks []MITREATTCK `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Remediation</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -28,17 +46,32 @@ type RemediationActivity struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
-
 	// Command UID: The unique identifier of the remediation command that pertains to this event.
 	CommandUid string `json:"command_uid" parquet:"command_uid"`
+
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
 
 	// Countermeasures: The MITRE DEFEND™ Matrix Countermeasures associated with a remediation.
 	Countermeasures []MITRED3FEND `json:"countermeasures,omitempty" parquet:"countermeasures,list,optional"`
+
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -49,6 +82,15 @@ type RemediationActivity struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
 
@@ -58,14 +100,26 @@ type RemediationActivity struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
 
 	// Remediation Guidance: Describes the recommended remediation steps to address identified issue(s).
 	Remediation *Remediation `json:"remediation,omitempty" parquet:"remediation,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Scan: The remediation scan that pertains to this event.
 	Scan *Scan `json:"scan,omitempty" parquet:"scan,optional"`
@@ -131,25 +185,43 @@ func (v *RemediationActivity) ValidateObservables() error {
 }
 
 var RemediationActivityFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
 	{Name: "command_uid", Type: arrow.BinaryTypes.String, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "countermeasures", Type: arrow.ListOf(MITRED3FENDStruct), Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "remediation", Type: RemediationStruct, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "scan", Type: ScanStruct, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},

--- a/ocsf/v1_4_0/scan_activity.go
+++ b/ocsf/v1_4_0/scan_activity.go
@@ -10,11 +10,29 @@ import (
 
 type ScanActivity struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
+
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® Details: An array of <a target='_blank' href='https://attack.mitre.org'>MITRE ATT&CK®</a> objects describing identified tactics, techniques & sub-techniques.
+	Attacks []MITREATTCK `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Application Activity</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -28,14 +46,29 @@ type ScanActivity struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
-
 	// Command UID: The command identifier that is associated with this scan event.  This ID uniquely identifies the proactive scan command, e.g., if remotely initiated.
 	CommandUid *string `json:"command_uid,omitempty" parquet:"command_uid,optional"`
 
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
+
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
+
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The duration of the scan
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -45,6 +78,15 @@ type ScanActivity struct {
 
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
+
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
 
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
@@ -82,11 +124,23 @@ type ScanActivity struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy associated with this Scan event; required if the scan was initiated by a policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Scan: The Scan object describes characteristics of the scan job.
 	Scan Scan `json:"scan" parquet:"scan"`
@@ -158,18 +212,32 @@ func (v *ScanActivity) ValidateObservables() error {
 }
 
 var ScanActivityFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
 	{Name: "command_uid", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "num_detections", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
@@ -182,8 +250,12 @@ var ScanActivityFields = []arrow.Field{
 	{Name: "num_skipped_items", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "num_trusted_items", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "scan", Type: ScanStruct, Nullable: false},
 	{Name: "schedule_uid", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},

--- a/ocsf/v1_4_0/scheduled_job_activity.go
+++ b/ocsf/v1_4_0/scheduled_job_activity.go
@@ -10,11 +10,29 @@ import (
 
 type ScheduledJobActivity struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
+
+	// Actor: The actor that performed the activity on the <code>job</code> object.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® Details: An array of <a target='_blank' href='https://attack.mitre.org'>MITRE ATT&CK®</a> objects describing identified tactics, techniques & sub-techniques.
+	Attacks []MITREATTCK `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>System Activity</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -28,14 +46,26 @@ type ScheduledJobActivity struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
 
 	// Device: An addressable device, computer system or host.
 	Device Device `json:"device" parquet:"device"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -46,8 +76,17 @@ type ScheduledJobActivity struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
 	// Job: The job object that pertains to the event.
 	Job Job `json:"job" parquet:"job"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
 
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
@@ -58,11 +97,23 @@ type ScheduledJobActivity struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the severity_id value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -125,24 +176,41 @@ func (v *ScheduledJobActivity) ValidateObservables() error {
 }
 
 var ScheduledJobActivityFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "device", Type: DeviceStruct, Nullable: false},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
 	{Name: "job", Type: JobStruct, Nullable: false},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "start_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},

--- a/ocsf/v1_4_0/script_activity.go
+++ b/ocsf/v1_4_0/script_activity.go
@@ -10,6 +10,12 @@ import (
 
 type ScriptActivity struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
@@ -18,6 +24,15 @@ type ScriptActivity struct {
 
 	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
 	Actor Actor `json:"actor" parquet:"actor"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® Details: An array of <a target='_blank' href='https://attack.mitre.org'>MITRE ATT&CK®</a> objects describing identified tactics, techniques & sub-techniques.
+	Attacks []MITREATTCK `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>System Activity</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -31,14 +46,26 @@ type ScriptActivity struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
 
 	// Device: An addressable device, computer system or host.
 	Device Device `json:"device" parquet:"device"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -49,6 +76,15 @@ type ScriptActivity struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
 
@@ -58,11 +94,23 @@ type ScriptActivity struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Script: The script that was the target of the activity.
 	Script Script `json:"script" parquet:"script"`
@@ -128,24 +176,40 @@ func (v *ScriptActivity) ValidateObservables() error {
 }
 
 var ScriptActivityFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "actor", Type: ActorStruct, Nullable: false},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "device", Type: DeviceStruct, Nullable: false},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "script", Type: ScriptStruct, Nullable: false},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},

--- a/ocsf/v1_4_0/security_finding.go
+++ b/ocsf/v1_4_0/security_finding.go
@@ -10,14 +10,32 @@ import (
 
 type SecurityFinding struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
 
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
 	// Analytic: The analytic technique used to analyze and derive insights from the data or information that led to the finding or conclusion.
 	Analytic *Analytic `json:"analytic,omitempty" parquet:"analytic,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® Details: An array of <a target='_blank' href='https://attack.mitre.org'>MITRE ATT&CK®</a> objects describing the tactics, techniques & sub-techniques associated to the Finding.
+	Attacks []MITREATTCK `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Findings</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -34,17 +52,32 @@ type SecurityFinding struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
-
 	// Compliance: The compliance object provides context to compliance findings (e.g., a check against a specific regulatory or best practice framework such as CIS, NIST etc.) and contains compliance related details.
 	Compliance *Compliance `json:"compliance,omitempty" parquet:"compliance,optional"`
+
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
 
 	// Data Sources: A list of data sources utilized in generation of the finding.
 	DataSources []string `json:"data_sources,omitempty" parquet:"data_sources,list,optional"`
+
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -58,6 +91,9 @@ type SecurityFinding struct {
 	// Finding: The Finding object provides details about a finding/detection generated by a security tool.
 	Finding Finding `json:"finding" parquet:"finding"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
 	// Impact: The impact , normalized to the caption of the impact_id value. In the case of 'Other', it is defined by the event source.
 	Impact *string `json:"impact,omitempty" parquet:"impact,optional"`
 
@@ -67,8 +103,14 @@ type SecurityFinding struct {
 	// Impact Score: The impact as an integer value of the finding, valid range 0-100.
 	ImpactScore *int32 `json:"impact_score,omitempty" parquet:"impact_score,optional"`
 
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
 	// Kill Chain: The <a target='_blank' href='https://www.lockheedmartin.com/en-us/capabilities/cyber/cyber-kill-chain.html'>Cyber Kill Chain®</a> provides a detailed description of each phase and its associated activities within the broader context of a cyber attack.
 	KillChain []KillChainPhase `json:"kill_chain,omitempty" parquet:"kill_chain,list,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
 
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
@@ -82,8 +124,8 @@ type SecurityFinding struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Process: The process object.
 	Process *Process `json:"process,omitempty" parquet:"process,optional"`
@@ -93,6 +135,18 @@ type SecurityFinding struct {
 
 	// Resources Array: Describes details about resources that were affected by the activity/event.
 	Resources []ResourceDetails `json:"resources,omitempty" parquet:"resources,list,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the severity_id value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -164,34 +218,52 @@ func (v *SecurityFinding) ValidateObservables() error {
 }
 
 var SecurityFindingFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
 	{Name: "analytic", Type: AnalyticStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "cis_csc", Type: arrow.ListOf(CISCSCStruct), Nullable: true},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
 	{Name: "compliance", Type: ComplianceStruct, Nullable: true},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "data_sources", Type: arrow.ListOf(arrow.BinaryTypes.String), Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
 	{Name: "finding", Type: FindingStruct, Nullable: false},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
 	{Name: "impact", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "impact_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "impact_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
 	{Name: "kill_chain", Type: arrow.ListOf(KillChainPhaseStruct), Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "nist", Type: arrow.ListOf(arrow.BinaryTypes.String), Nullable: true},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "process", Type: ProcessStruct, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "resources", Type: arrow.ListOf(ResourceDetailsStruct), Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "start_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},

--- a/ocsf/v1_4_0/service_query.go
+++ b/ocsf/v1_4_0/service_query.go
@@ -10,11 +10,29 @@ import (
 
 type ServiceQuery struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
+
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® Details: An array of <a target='_blank' href='https://attack.mitre.org'>MITRE ATT&CK®</a> objects describing identified tactics, techniques & sub-techniques.
+	Attacks []MITREATTCK `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Discovery</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -28,11 +46,26 @@ type ServiceQuery struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
+
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -43,6 +76,15 @@ type ServiceQuery struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
 
@@ -52,8 +94,8 @@ type ServiceQuery struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Query Info: The search details associated with the query request.
 	QueryInfo *QueryInformation `json:"query_info,omitempty" parquet:"query_info,optional"`
@@ -66,6 +108,18 @@ type ServiceQuery struct {
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Service: The service that pertains to the event.
 	Service Service `json:"service" parquet:"service"`
@@ -131,25 +185,43 @@ func (v *ServiceQuery) ValidateObservables() error {
 }
 
 var ServiceQueryFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "query_info", Type: QueryInformationStruct, Nullable: true},
 	{Name: "query_result", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "query_result_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "service", Type: ServiceStruct, Nullable: false},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},

--- a/ocsf/v1_4_0/session_query.go
+++ b/ocsf/v1_4_0/session_query.go
@@ -10,11 +10,29 @@ import (
 
 type UserSessionQuery struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
+
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® Details: An array of <a target='_blank' href='https://attack.mitre.org'>MITRE ATT&CK®</a> objects describing identified tactics, techniques & sub-techniques.
+	Attacks []MITREATTCK `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Discovery</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -28,11 +46,26 @@ type UserSessionQuery struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
+
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -43,6 +76,15 @@ type UserSessionQuery struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
 
@@ -52,8 +94,8 @@ type UserSessionQuery struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Query Info: The search details associated with the query request.
 	QueryInfo *QueryInformation `json:"query_info,omitempty" parquet:"query_info,optional"`
@@ -66,6 +108,18 @@ type UserSessionQuery struct {
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Session: The authenticated user or service session.
 	Session Session `json:"session" parquet:"session"`
@@ -131,25 +185,43 @@ func (v *UserSessionQuery) ValidateObservables() error {
 }
 
 var UserSessionQueryFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "query_info", Type: QueryInformationStruct, Nullable: true},
 	{Name: "query_result", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "query_result_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "session", Type: SessionStruct, Nullable: false},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},

--- a/ocsf/v1_4_0/smb_activity.go
+++ b/ocsf/v1_4_0/smb_activity.go
@@ -10,14 +10,32 @@ import (
 
 type SMBActivity struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
 
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
 	// Application Name: The name of the application associated with the event or object.
 	AppName *string `json:"app_name,omitempty" parquet:"app_name,optional"`
+
+	// MITRE ATT&CK® Details: An array of <a target='_blank' href='https://attack.mitre.org'>MITRE ATT&CK®</a> objects describing identified tactics, techniques & sub-techniques.
+	Attacks []MITREATTCK `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Network Activity</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -34,11 +52,17 @@ type SMBActivity struct {
 	// Client Dialects: The list of SMB dialects that the client speaks.
 	ClientDialects []string `json:"client_dialects,omitempty" parquet:"client_dialects,list,optional"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
-
 	// Command: The command name (e.g. SMB2_COMMAND_CREATE, SMB1_COMMAND_WRITE_ANDX).
 	Command *string `json:"command,omitempty" parquet:"command,optional"`
+
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Connection Info: The network connection information.
 	ConnectionInfo *NetworkConnectionInformation `json:"connection_info,omitempty" parquet:"connection_info,optional"`
@@ -49,8 +73,17 @@ type SMBActivity struct {
 	// Distributed Computing Environment/Remote Procedure Call (DCE/RPC): The DCE/RPC object describes the remote procedure call system for distributed computing environments.
 	DceRpc *DCERPC `json:"dce_rpc,omitempty" parquet:"dce_rpc,optional"`
 
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
 	// Dialect: The negotiated protocol dialect.
 	Dialect *string `json:"dialect,omitempty" parquet:"dialect,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Destination Endpoint: The responder (server) in a network connection.
 	DstEndpoint *NetworkEndpoint `json:"dst_endpoint,omitempty" parquet:"dst_endpoint,optional"`
@@ -67,8 +100,17 @@ type SMBActivity struct {
 	// File: The file that is the target of the SMB activity.
 	File *File `json:"file,omitempty" parquet:"file,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
 	// JA4+ Fingerprints: A list of the JA4+ network fingerprints.
 	Ja4FingerprintList []JA4Fingerprint `json:"ja4_fingerprint_list,omitempty" parquet:"ja4_fingerprint_list,list,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
 
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
@@ -82,14 +124,44 @@ type SMBActivity struct {
 	// Open Type: Indicates how the file was opened (e.g. normal, delete on close).
 	OpenType *string `json:"open_type,omitempty" parquet:"open_type,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
+
+	// Proxy Connection Info: The connection information from the proxy server to the remote server.
+	ProxyConnectionInfo *NetworkConnectionInformation `json:"proxy_connection_info,omitempty" parquet:"proxy_connection_info,optional"`
+
+	// Proxy Endpoint: The proxy (server) in a network connection.
+	ProxyEndpoint *NetworkProxyEndpoint `json:"proxy_endpoint,omitempty" parquet:"proxy_endpoint,optional"`
+
+	// Proxy HTTP Request: The HTTP Request from the proxy server to the remote server.
+	ProxyHttpRequest *HTTPRequest `json:"proxy_http_request,omitempty" parquet:"proxy_http_request,optional"`
+
+	// Proxy HTTP Response: The HTTP Response from the remote server to the proxy server.
+	ProxyHttpResponse *HTTPResponse `json:"proxy_http_response,omitempty" parquet:"proxy_http_response,optional"`
+
+	// Proxy TLS: The TLS protocol negotiated between the proxy server and the remote server.
+	ProxyTls *TransportLayerSecurityTLS `json:"proxy_tls,omitempty" parquet:"proxy_tls,optional"`
+
+	// Proxy Traffic: The network traffic refers to the amount of data moving across a network, from proxy to remote server at a given point of time.
+	ProxyTraffic *NetworkTraffic `json:"proxy_traffic,omitempty" parquet:"proxy_traffic,optional"`
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
 
 	// API Response Details: The server response in an SMB network connection.
 	Response *ResponseElements `json:"response,omitempty" parquet:"response,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the severity_id value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -173,33 +245,57 @@ func (v *SMBActivity) ValidateObservables() error {
 }
 
 var SMBActivityFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
 	{Name: "app_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "client_dialects", Type: arrow.ListOf(arrow.BinaryTypes.String), Nullable: true},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
 	{Name: "command", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "connection_info", Type: NetworkConnectionInformationStruct, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "dce_rpc", Type: DCERPCStruct, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
 	{Name: "dialect", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "dst_endpoint", Type: NetworkEndpointStruct, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
 	{Name: "file", Type: FileStruct, Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
 	{Name: "ja4_fingerprint_list", Type: arrow.ListOf(JA4FingerprintStruct), Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
 	{Name: "open_type", Type: arrow.BinaryTypes.String, Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
+	{Name: "proxy_connection_info", Type: NetworkConnectionInformationStruct, Nullable: true},
+	{Name: "proxy_endpoint", Type: NetworkProxyEndpointStruct, Nullable: true},
+	{Name: "proxy_http_request", Type: HTTPRequestStruct, Nullable: true},
+	{Name: "proxy_http_response", Type: HTTPResponseStruct, Nullable: true},
+	{Name: "proxy_tls", Type: TransportLayerSecurityTLSStruct, Nullable: true},
+	{Name: "proxy_traffic", Type: NetworkTrafficStruct, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "response", Type: ResponseElementsStruct, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "share", Type: arrow.BinaryTypes.String, Nullable: true},

--- a/ocsf/v1_4_0/software_info.go
+++ b/ocsf/v1_4_0/software_info.go
@@ -10,11 +10,29 @@ import (
 
 type SoftwareInventoryInfo struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
+
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® Details: An array of <a target='_blank' href='https://attack.mitre.org'>MITRE ATT&CK®</a> objects describing identified tactics, techniques & sub-techniques.
+	Attacks []MITREATTCK `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Discovery</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -28,14 +46,26 @@ type SoftwareInventoryInfo struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
 
 	// Device: The device that is being discovered by an inventory process.
 	Device Device `json:"device" parquet:"device"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -46,6 +76,15 @@ type SoftwareInventoryInfo struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
 
@@ -55,14 +94,26 @@ type SoftwareInventoryInfo struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Product: Additional product attributes that have been discovered or enriched from a catalog or other external source.
 	Product *Product `json:"product,omitempty" parquet:"product,optional"`
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Software Bill Of Materials: The Software Bill of Materials (SBOM) of the device software that is being discovered by an inventory process.
 	Sbom *SoftwareBillofMaterials `json:"sbom,omitempty" parquet:"sbom,optional"`
@@ -128,24 +179,41 @@ func (v *SoftwareInventoryInfo) ValidateObservables() error {
 }
 
 var SoftwareInventoryInfoFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "device", Type: DeviceStruct, Nullable: false},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "product", Type: ProductStruct, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "sbom", Type: SoftwareBillofMaterialsStruct, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},

--- a/ocsf/v1_4_0/ssh_activity.go
+++ b/ocsf/v1_4_0/ssh_activity.go
@@ -10,20 +10,38 @@ import (
 
 type SSHActivity struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
 
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
 	// Application Name: The name of the application associated with the event or object.
 	AppName *string `json:"app_name,omitempty" parquet:"app_name,optional"`
+
+	// MITRE ATT&CK® Details: An array of <a target='_blank' href='https://attack.mitre.org'>MITRE ATT&CK®</a> objects describing identified tactics, techniques & sub-techniques.
+	Attacks []MITREATTCK `json:"attacks,omitempty" parquet:"attacks,list,optional"`
 
 	// Authentication Type: The SSH authentication type, normalized to the caption of 'auth_type_id'. In the case of 'Other', it is defined by the event source.
 	AuthType *string `json:"auth_type,omitempty" parquet:"auth_type,optional"`
 
 	// Authentication Type ID: The normalized identifier of the SSH authentication type.
 	AuthTypeId *int32 `json:"auth_type_id,omitempty" parquet:"auth_type_id,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Network Activity</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -40,14 +58,29 @@ type SSHActivity struct {
 	// Client HASSH: The Client HASSH fingerprinting object.
 	ClientHassh *HASSH `json:"client_hassh,omitempty" parquet:"client_hassh,optional"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Connection Info: The network connection information.
 	ConnectionInfo *NetworkConnectionInformation `json:"connection_info,omitempty" parquet:"connection_info,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
+
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Destination Endpoint: The responder (server) in a network connection.
 	DstEndpoint *NetworkEndpoint `json:"dst_endpoint,omitempty" parquet:"dst_endpoint,optional"`
@@ -64,8 +97,17 @@ type SSHActivity struct {
 	// File: The file that is the target of the SSH activity.
 	File *File `json:"file,omitempty" parquet:"file,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
 	// JA4+ Fingerprints: A list of the JA4+ network fingerprints.
 	Ja4FingerprintList []JA4Fingerprint `json:"ja4_fingerprint_list,omitempty" parquet:"ja4_fingerprint_list,list,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
 
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
@@ -76,14 +118,44 @@ type SSHActivity struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// SSH Version: The Secure Shell Protocol version.
 	ProtocolVer *string `json:"protocol_ver,omitempty" parquet:"protocol_ver,optional"`
 
+	// Proxy Connection Info: The connection information from the proxy server to the remote server.
+	ProxyConnectionInfo *NetworkConnectionInformation `json:"proxy_connection_info,omitempty" parquet:"proxy_connection_info,optional"`
+
+	// Proxy Endpoint: The proxy (server) in a network connection.
+	ProxyEndpoint *NetworkProxyEndpoint `json:"proxy_endpoint,omitempty" parquet:"proxy_endpoint,optional"`
+
+	// Proxy HTTP Request: The HTTP Request from the proxy server to the remote server.
+	ProxyHttpRequest *HTTPRequest `json:"proxy_http_request,omitempty" parquet:"proxy_http_request,optional"`
+
+	// Proxy HTTP Response: The HTTP Response from the remote server to the proxy server.
+	ProxyHttpResponse *HTTPResponse `json:"proxy_http_response,omitempty" parquet:"proxy_http_response,optional"`
+
+	// Proxy TLS: The TLS protocol negotiated between the proxy server and the remote server.
+	ProxyTls *TransportLayerSecurityTLS `json:"proxy_tls,omitempty" parquet:"proxy_tls,optional"`
+
+	// Proxy Traffic: The network traffic refers to the amount of data moving across a network, from proxy to remote server at a given point of time.
+	ProxyTraffic *NetworkTraffic `json:"proxy_traffic,omitempty" parquet:"proxy_traffic,optional"`
+
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Server HASSH: The Server HASSH fingerprinting object.
 	ServerHassh *HASSH `json:"server_hassh,omitempty" parquet:"server_hassh,optional"`
@@ -158,31 +230,55 @@ func (v *SSHActivity) ValidateObservables() error {
 }
 
 var SSHActivityFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
 	{Name: "app_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKStruct), Nullable: true},
 	{Name: "auth_type", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "auth_type_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "client_hassh", Type: HASSHStruct, Nullable: true},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "connection_info", Type: NetworkConnectionInformationStruct, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "dst_endpoint", Type: NetworkEndpointStruct, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
 	{Name: "file", Type: FileStruct, Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
 	{Name: "ja4_fingerprint_list", Type: arrow.ListOf(JA4FingerprintStruct), Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "protocol_ver", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "proxy_connection_info", Type: NetworkConnectionInformationStruct, Nullable: true},
+	{Name: "proxy_endpoint", Type: NetworkProxyEndpointStruct, Nullable: true},
+	{Name: "proxy_http_request", Type: HTTPRequestStruct, Nullable: true},
+	{Name: "proxy_http_response", Type: HTTPResponseStruct, Nullable: true},
+	{Name: "proxy_tls", Type: TransportLayerSecurityTLSStruct, Nullable: true},
+	{Name: "proxy_traffic", Type: NetworkTrafficStruct, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "server_hassh", Type: HASSHStruct, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},

--- a/ocsf/v1_4_0/startup_item_query.go
+++ b/ocsf/v1_4_0/startup_item_query.go
@@ -10,11 +10,29 @@ import (
 
 type StartupItemQuery struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
+
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® Details: An array of <a target='_blank' href='https://attack.mitre.org'>MITRE ATT&CK®</a> objects describing identified tactics, techniques & sub-techniques.
+	Attacks []MITREATTCK `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Discovery</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -28,11 +46,26 @@ type StartupItemQuery struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
+
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -43,6 +76,15 @@ type StartupItemQuery struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
 
@@ -52,8 +94,8 @@ type StartupItemQuery struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Query Info: The search details associated with the query request.
 	QueryInfo *QueryInformation `json:"query_info,omitempty" parquet:"query_info,optional"`
@@ -66,6 +108,18 @@ type StartupItemQuery struct {
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the severity_id value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -131,25 +185,43 @@ func (v *StartupItemQuery) ValidateObservables() error {
 }
 
 var StartupItemQueryFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "query_info", Type: QueryInformationStruct, Nullable: true},
 	{Name: "query_result", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "query_result_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "start_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},

--- a/ocsf/v1_4_0/tunnel_activity.go
+++ b/ocsf/v1_4_0/tunnel_activity.go
@@ -10,14 +10,32 @@ import (
 
 type TunnelActivity struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
 
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
 	// Application Name: The name of the application associated with the event or object.
 	AppName *string `json:"app_name,omitempty" parquet:"app_name,optional"`
+
+	// MITRE ATT&CK® Details: An array of <a target='_blank' href='https://attack.mitre.org'>MITRE ATT&CK®</a> objects describing identified tactics, techniques & sub-techniques.
+	Attacks []MITREATTCK `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Network Activity</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -31,14 +49,29 @@ type TunnelActivity struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Connection Info: The tunnel connection information.
 	ConnectionInfo *NetworkConnectionInformation `json:"connection_info,omitempty" parquet:"connection_info,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
+
+	// Device: The device that reported the event.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Destination Endpoint: The server responding to the tunnel connection.
 	DstEndpoint *NetworkEndpoint `json:"dst_endpoint,omitempty" parquet:"dst_endpoint,optional"`
@@ -52,8 +85,17 @@ type TunnelActivity struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
 	// JA4+ Fingerprints: A list of the JA4+ network fingerprints.
 	Ja4FingerprintList []JA4Fingerprint `json:"ja4_fingerprint_list,omitempty" parquet:"ja4_fingerprint_list,list,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
 
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
@@ -64,14 +106,44 @@ type TunnelActivity struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Tunnel Protocol: The networking protocol associated with the tunnel. E.g. <code>IPSec</code>, <code>SSL</code>, <code>GRE</code>.
 	ProtocolName *string `json:"protocol_name,omitempty" parquet:"protocol_name,optional"`
 
+	// Proxy Connection Info: The connection information from the proxy server to the remote server.
+	ProxyConnectionInfo *NetworkConnectionInformation `json:"proxy_connection_info,omitempty" parquet:"proxy_connection_info,optional"`
+
+	// Proxy Endpoint: The proxy (server) in a network connection.
+	ProxyEndpoint *NetworkProxyEndpoint `json:"proxy_endpoint,omitempty" parquet:"proxy_endpoint,optional"`
+
+	// Proxy HTTP Request: The HTTP Request from the proxy server to the remote server.
+	ProxyHttpRequest *HTTPRequest `json:"proxy_http_request,omitempty" parquet:"proxy_http_request,optional"`
+
+	// Proxy HTTP Response: The HTTP Response from the remote server to the proxy server.
+	ProxyHttpResponse *HTTPResponse `json:"proxy_http_response,omitempty" parquet:"proxy_http_response,optional"`
+
+	// Proxy TLS: The TLS protocol negotiated between the proxy server and the remote server.
+	ProxyTls *TransportLayerSecurityTLS `json:"proxy_tls,omitempty" parquet:"proxy_tls,optional"`
+
+	// Proxy Traffic: The network traffic refers to the amount of data moving across a network, from proxy to remote server at a given point of time.
+	ProxyTraffic *NetworkTraffic `json:"proxy_traffic,omitempty" parquet:"proxy_traffic,optional"`
+
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Tunnel Session: The session associated with the tunnel.
 	Session *Session `json:"session,omitempty" parquet:"session,optional"`
@@ -158,27 +230,51 @@ func (v *TunnelActivity) ValidateObservables() error {
 }
 
 var TunnelActivityFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
 	{Name: "app_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "connection_info", Type: NetworkConnectionInformationStruct, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "dst_endpoint", Type: NetworkEndpointStruct, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
 	{Name: "ja4_fingerprint_list", Type: arrow.ListOf(JA4FingerprintStruct), Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "protocol_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "proxy_connection_info", Type: NetworkConnectionInformationStruct, Nullable: true},
+	{Name: "proxy_endpoint", Type: NetworkProxyEndpointStruct, Nullable: true},
+	{Name: "proxy_http_request", Type: HTTPRequestStruct, Nullable: true},
+	{Name: "proxy_http_response", Type: HTTPResponseStruct, Nullable: true},
+	{Name: "proxy_tls", Type: TransportLayerSecurityTLSStruct, Nullable: true},
+	{Name: "proxy_traffic", Type: NetworkTrafficStruct, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "session", Type: SessionStruct, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},

--- a/ocsf/v1_4_0/user_access.go
+++ b/ocsf/v1_4_0/user_access.go
@@ -10,11 +10,29 @@ import (
 
 type UserAccessManagement struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
+
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® Details: An array of <a target='_blank' href='https://attack.mitre.org'>MITRE ATT&CK®</a> objects describing identified tactics, techniques & sub-techniques.
+	Attacks []MITREATTCK `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Identity & Access Management</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -28,11 +46,26 @@ type UserAccessManagement struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
+
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -43,11 +76,20 @@ type UserAccessManagement struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
 	// HTTP Request: Details about the underlying HTTP request.
 	HttpRequest *HTTPRequest `json:"http_request,omitempty" parquet:"http_request,optional"`
 
 	// HTTP Response: Details about the underlying HTTP response.
 	HttpResponse *HTTPResponse `json:"http_response,omitempty" parquet:"http_response,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
 
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
@@ -58,8 +100,8 @@ type UserAccessManagement struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Privileges: List of privileges assigned to a user.
 	Privileges []string `json:"privileges" parquet:"privileges,list"`
@@ -69,6 +111,18 @@ type UserAccessManagement struct {
 
 	// Resource: Resource that the privileges give access to.
 	Resource *ResourceDetails `json:"resource,omitempty" parquet:"resource,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the severity_id value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -137,26 +191,44 @@ func (v *UserAccessManagement) ValidateObservables() error {
 }
 
 var UserAccessManagementFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
 	{Name: "http_request", Type: HTTPRequestStruct, Nullable: true},
 	{Name: "http_response", Type: HTTPResponseStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "privileges", Type: arrow.ListOf(arrow.BinaryTypes.String), Nullable: false},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "resource", Type: ResourceDetailsStruct, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "src_endpoint", Type: NetworkEndpointStruct, Nullable: true},

--- a/ocsf/v1_4_0/user_inventory.go
+++ b/ocsf/v1_4_0/user_inventory.go
@@ -10,11 +10,29 @@ import (
 
 type UserInventoryInfo struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
+
+	// Actor: The actor describes the process that was the source of the inventory activity. In the case of user inventory data, that could be a particular process or script that is run to scrape the user data. For example, it could be a powershell process that runs to pull data from the Azure AD graph API.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® Details: An array of <a target='_blank' href='https://attack.mitre.org'>MITRE ATT&CK®</a> objects describing identified tactics, techniques & sub-techniques.
+	Attacks []MITREATTCK `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Discovery</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -28,11 +46,26 @@ type UserInventoryInfo struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
+
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -43,6 +76,15 @@ type UserInventoryInfo struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
 
@@ -52,11 +94,23 @@ type UserInventoryInfo struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the severity_id value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -122,22 +176,40 @@ func (v *UserInventoryInfo) ValidateObservables() error {
 }
 
 var UserInventoryInfoFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "start_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},

--- a/ocsf/v1_4_0/user_query.go
+++ b/ocsf/v1_4_0/user_query.go
@@ -10,11 +10,29 @@ import (
 
 type UserQuery struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
+
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® Details: An array of <a target='_blank' href='https://attack.mitre.org'>MITRE ATT&CK®</a> objects describing identified tactics, techniques & sub-techniques.
+	Attacks []MITREATTCK `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Discovery</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -28,11 +46,26 @@ type UserQuery struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
+
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -43,6 +76,15 @@ type UserQuery struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
 
@@ -52,8 +94,8 @@ type UserQuery struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Query Info: The search details associated with the query request.
 	QueryInfo *QueryInformation `json:"query_info,omitempty" parquet:"query_info,optional"`
@@ -66,6 +108,18 @@ type UserQuery struct {
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the severity_id value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -131,25 +185,43 @@ func (v *UserQuery) ValidateObservables() error {
 }
 
 var UserQueryFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "query_info", Type: QueryInformationStruct, Nullable: true},
 	{Name: "query_result", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "query_result_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "start_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},

--- a/ocsf/v1_4_0/vulnerability_finding.go
+++ b/ocsf/v1_4_0/vulnerability_finding.go
@@ -10,11 +10,35 @@ import (
 
 type VulnerabilityFinding struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the finding activity.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The finding activity name, as defined by the <code>activity_id</code>.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
+
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// Assignee: The details of the user assigned to an Incident.
+	Assignee *User `json:"assignee,omitempty" parquet:"assignee,optional"`
+
+	// Assignee Group: The details of the group assigned to an Incident.
+	AssigneeGroup *Group `json:"assignee_group,omitempty" parquet:"assignee_group,optional"`
+
+	// MITRE ATT&CK® Details: An array of <a target='_blank' href='https://attack.mitre.org'>MITRE ATT&CK®</a> objects describing identified tactics, techniques & sub-techniques.
+	Attacks []MITREATTCK `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Findings</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -28,14 +52,29 @@ type VulnerabilityFinding struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
-
 	// Comment: A user provided comment about the finding.
 	Comment *string `json:"comment,omitempty" parquet:"comment,optional"`
 
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
+
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
+
+	// Device: Describes the affected device/host. It can be used in conjunction with <code>Affected Resource(s)</code>. <p> e.g. Specific details about an AWS EC2 instance, that is affected by the Finding.</p>
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -49,6 +88,27 @@ type VulnerabilityFinding struct {
 	// Finding Information: Describes the supporting information about a generated finding.
 	FindingInfo FindingInformation `json:"finding_info" parquet:"finding_info"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Impact: The impact , normalized to the caption of the impact_id value. In the case of 'Other', it is defined by the event source.
+	Impact *string `json:"impact,omitempty" parquet:"impact,optional"`
+
+	// Impact ID: The normalized impact of the incident or finding. Per NIST, this is the magnitude of harm that can be expected to result from the consequences of unauthorized disclosure, modification, destruction, or loss of information or information system availability.
+	ImpactId *int32 `json:"impact_id,omitempty" parquet:"impact_id,optional"`
+
+	// Impact Score: The impact as an integer value of the finding, valid range 0-100.
+	ImpactScore *int32 `json:"impact_score,omitempty" parquet:"impact_score,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Suspected Breach: A determination based on analytics as to whether a potential breach was found.
+	IsSuspectedBreach *bool `json:"is_suspected_breach,omitempty" parquet:"is_suspected_breach,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
 
@@ -58,8 +118,14 @@ type VulnerabilityFinding struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
+
+	// Priority: The priority, normalized to the caption of the priority_id value. In the case of 'Other', it is defined by the event source.
+	Priority *string `json:"priority,omitempty" parquet:"priority,optional"`
+
+	// Priority ID: The normalized priority. Priority identifies the relative importance of the incident or finding. It is a measurement of urgency.
+	PriorityId *int32 `json:"priority_id,omitempty" parquet:"priority_id,optional"`
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
@@ -67,11 +133,26 @@ type VulnerabilityFinding struct {
 	// Affected Resources: Describes details about the resource/resources that are affected by the vulnerability/vulnerabilities.
 	Resources []ResourceDetails `json:"resources,omitempty" parquet:"resources,list,optional"`
 
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
+
 	// Severity: The event/finding severity, normalized to the caption of the severity_id value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
 
 	// Severity ID: <p>The normalized identifier of the event/finding severity.</p>The normalized severity is a measurement the effort and expense required to manage and resolve an event or incident. Smaller numerical values represent lower impact events, and larger numerical values represent higher impact events.
 	SeverityId int32 `json:"severity_id" parquet:"severity_id"`
+
+	// Source URL: A Url link used to access the original incident.
+	SrcUrl *string `json:"src_url,omitempty" parquet:"src_url,optional"`
 
 	// Start Time: The time of the least recent event included in the finding.
 	StartTime int64 `json:"start_time,omitempty" parquet:"start_time,timestamp_millis,timestamp(millisecond),optional"`
@@ -87,6 +168,9 @@ type VulnerabilityFinding struct {
 
 	// Status ID: The normalized status identifier of the Finding, set by the consumer.
 	StatusId *int32 `json:"status_id,omitempty" parquet:"status_id,optional"`
+
+	// Ticket: The linked ticket in the ticketing system.
+	Ticket *Ticket `json:"ticket,omitempty" parquet:"ticket,optional"`
 
 	// Event Time: The normalized event occurrence time or the finding creation time.
 	Time int64 `json:"time" parquet:"time,timestamp_millis,timestamp(millisecond)"`
@@ -105,6 +189,12 @@ type VulnerabilityFinding struct {
 
 	// Vendor Attributes: The Vendor Attributes object can be used to represent values of attributes populated by the Vendor/Finding Provider. It can help distinguish between the vendor-prodvided values and consumer-updated values, of key attributes like <code>severity_id</code>.<br>The original finding producer should not populate this object. It should be populated by consuming systems that support data mutability.
 	VendorAttributes *VendorAttributes `json:"vendor_attributes,omitempty" parquet:"vendor_attributes,optional"`
+
+	// Verdict: The verdict assigned to an Incident finding.
+	Verdict *string `json:"verdict,omitempty" parquet:"verdict,optional"`
+
+	// Verdict ID: The normalized verdict of an Incident.
+	VerdictId *int32 `json:"verdict_id,omitempty" parquet:"verdict_id,optional"`
 
 	// Vulnerabilities: This object describes vulnerabilities reported in a security finding.
 	Vulnerabilities []VulnerabilityDetails `json:"vulnerabilities" parquet:"vulnerabilities,list"`
@@ -134,38 +224,68 @@ func (v *VulnerabilityFinding) ValidateObservables() error {
 }
 
 var VulnerabilityFindingFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "assignee", Type: UserStruct, Nullable: true},
+	{Name: "assignee_group", Type: GroupStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
 	{Name: "comment", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
 	{Name: "finding_info", Type: FindingInformationStruct, Nullable: false},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "impact", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "impact_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "impact_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "is_suspected_breach", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
+	{Name: "priority", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "priority_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "resources", Type: arrow.ListOf(ResourceDetailsStruct), Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
+	{Name: "src_url", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "start_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "status", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "status_code", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "status_detail", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "status_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "ticket", Type: TicketStruct, Nullable: true},
 	{Name: "time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: false},
 	{Name: "timezone_offset", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "type_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "type_uid", Type: arrow.PrimitiveTypes.Int64, Nullable: false},
 	{Name: "unmapped", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "vendor_attributes", Type: VendorAttributesStruct, Nullable: true},
+	{Name: "verdict", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "verdict_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "vulnerabilities", Type: arrow.ListOf(VulnerabilityDetailsStruct), Nullable: false},
 }
 

--- a/ocsf/v1_4_0/web_resource_access_activity.go
+++ b/ocsf/v1_4_0/web_resource_access_activity.go
@@ -10,11 +10,29 @@ import (
 
 type WebResourceAccessActivity struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
+
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® Details: An array of <a target='_blank' href='https://attack.mitre.org'>MITRE ATT&CK®</a> objects describing identified tactics, techniques & sub-techniques.
+	Attacks []MITREATTCK `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Application Activity</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -28,11 +46,26 @@ type WebResourceAccessActivity struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
+
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -43,11 +76,20 @@ type WebResourceAccessActivity struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
 	// HTTP Request: Details about the underlying HTTP request.
 	HttpRequest HTTPRequest `json:"http_request" parquet:"http_request"`
 
 	// HTTP Response: Details about the HTTP response, if available.
 	HttpResponse *HTTPResponse `json:"http_response,omitempty" parquet:"http_response,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
 
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
@@ -58,11 +100,41 @@ type WebResourceAccessActivity struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
+
+	// Proxy Connection Info: The connection information from the proxy server to the remote server.
+	ProxyConnectionInfo *NetworkConnectionInformation `json:"proxy_connection_info,omitempty" parquet:"proxy_connection_info,optional"`
+
+	// Proxy Endpoint: The proxy (server) in a network connection.
+	ProxyEndpoint *NetworkProxyEndpoint `json:"proxy_endpoint,omitempty" parquet:"proxy_endpoint,optional"`
+
+	// Proxy HTTP Request: The HTTP Request from the proxy server to the remote server.
+	ProxyHttpRequest *HTTPRequest `json:"proxy_http_request,omitempty" parquet:"proxy_http_request,optional"`
+
+	// Proxy HTTP Response: The HTTP Response from the remote server to the proxy server.
+	ProxyHttpResponse *HTTPResponse `json:"proxy_http_response,omitempty" parquet:"proxy_http_response,optional"`
+
+	// Proxy TLS: The TLS protocol negotiated between the proxy server and the remote server.
+	ProxyTls *TransportLayerSecurityTLS `json:"proxy_tls,omitempty" parquet:"proxy_tls,optional"`
+
+	// Proxy Traffic: The network traffic refers to the amount of data moving across a network, from proxy to remote server at a given point of time.
+	ProxyTraffic *NetworkTraffic `json:"proxy_traffic,omitempty" parquet:"proxy_traffic,optional"`
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the severity_id value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -134,24 +206,48 @@ func (v *WebResourceAccessActivity) ValidateObservables() error {
 }
 
 var WebResourceAccessActivityFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
 	{Name: "http_request", Type: HTTPRequestStruct, Nullable: false},
 	{Name: "http_response", Type: HTTPResponseStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
+	{Name: "proxy_connection_info", Type: NetworkConnectionInformationStruct, Nullable: true},
+	{Name: "proxy_endpoint", Type: NetworkProxyEndpointStruct, Nullable: true},
+	{Name: "proxy_http_request", Type: HTTPRequestStruct, Nullable: true},
+	{Name: "proxy_http_response", Type: HTTPResponseStruct, Nullable: true},
+	{Name: "proxy_tls", Type: TransportLayerSecurityTLSStruct, Nullable: true},
+	{Name: "proxy_traffic", Type: NetworkTrafficStruct, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "src_endpoint", Type: NetworkEndpointStruct, Nullable: true},

--- a/ocsf/v1_4_0/web_resources_activity.go
+++ b/ocsf/v1_4_0/web_resources_activity.go
@@ -10,11 +10,29 @@ import (
 
 type WebResourcesActivity struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
+
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® Details: An array of <a target='_blank' href='https://attack.mitre.org'>MITRE ATT&CK®</a> objects describing identified tactics, techniques & sub-techniques.
+	Attacks []MITREATTCK `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Application Activity</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -28,11 +46,26 @@ type WebResourcesActivity struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
+
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Destination Endpoint: Details about server providing the web resources.
 	DstEndpoint *NetworkEndpoint `json:"dst_endpoint,omitempty" parquet:"dst_endpoint,optional"`
@@ -46,11 +79,20 @@ type WebResourcesActivity struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
 	// HTTP Request: Details about the underlying HTTP request.
 	HttpRequest *HTTPRequest `json:"http_request,omitempty" parquet:"http_request,optional"`
 
 	// HTTP Response: Details about the HTTP response, if available.
 	HttpResponse *HTTPResponse `json:"http_response,omitempty" parquet:"http_response,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
 
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
@@ -61,11 +103,41 @@ type WebResourcesActivity struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
+
+	// Proxy Connection Info: The connection information from the proxy server to the remote server.
+	ProxyConnectionInfo *NetworkConnectionInformation `json:"proxy_connection_info,omitempty" parquet:"proxy_connection_info,optional"`
+
+	// Proxy Endpoint: The proxy (server) in a network connection.
+	ProxyEndpoint *NetworkProxyEndpoint `json:"proxy_endpoint,omitempty" parquet:"proxy_endpoint,optional"`
+
+	// Proxy HTTP Request: The HTTP Request from the proxy server to the remote server.
+	ProxyHttpRequest *HTTPRequest `json:"proxy_http_request,omitempty" parquet:"proxy_http_request,optional"`
+
+	// Proxy HTTP Response: The HTTP Response from the remote server to the proxy server.
+	ProxyHttpResponse *HTTPResponse `json:"proxy_http_response,omitempty" parquet:"proxy_http_response,optional"`
+
+	// Proxy TLS: The TLS protocol negotiated between the proxy server and the remote server.
+	ProxyTls *TransportLayerSecurityTLS `json:"proxy_tls,omitempty" parquet:"proxy_tls,optional"`
+
+	// Proxy Traffic: The network traffic refers to the amount of data moving across a network, from proxy to remote server at a given point of time.
+	ProxyTraffic *NetworkTraffic `json:"proxy_traffic,omitempty" parquet:"proxy_traffic,optional"`
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the severity_id value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -140,25 +212,49 @@ func (v *WebResourcesActivity) ValidateObservables() error {
 }
 
 var WebResourcesActivityFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "dst_endpoint", Type: NetworkEndpointStruct, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
 	{Name: "http_request", Type: HTTPRequestStruct, Nullable: true},
 	{Name: "http_response", Type: HTTPResponseStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
+	{Name: "proxy_connection_info", Type: NetworkConnectionInformationStruct, Nullable: true},
+	{Name: "proxy_endpoint", Type: NetworkProxyEndpointStruct, Nullable: true},
+	{Name: "proxy_http_request", Type: HTTPRequestStruct, Nullable: true},
+	{Name: "proxy_http_response", Type: HTTPResponseStruct, Nullable: true},
+	{Name: "proxy_tls", Type: TransportLayerSecurityTLSStruct, Nullable: true},
+	{Name: "proxy_traffic", Type: NetworkTrafficStruct, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "src_endpoint", Type: NetworkEndpointStruct, Nullable: true},

--- a/ocsf/v1_4_0/windows_resource_activity.go
+++ b/ocsf/v1_4_0/windows_resource_activity.go
@@ -10,6 +10,12 @@ import (
 
 type WindowsResourceActivity struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
@@ -18,6 +24,15 @@ type WindowsResourceActivity struct {
 
 	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
 	Actor Actor `json:"actor" parquet:"actor"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® Details: An array of <a target='_blank' href='https://attack.mitre.org'>MITRE ATT&CK®</a> objects describing identified tactics, techniques & sub-techniques.
+	Attacks []MITREATTCK `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>System Activity</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -31,14 +46,26 @@ type WindowsResourceActivity struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
 
 	// Device: An addressable device, computer system or host.
 	Device Device `json:"device" parquet:"device"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -49,6 +76,15 @@ type WindowsResourceActivity struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
 
@@ -58,11 +94,23 @@ type WindowsResourceActivity struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the severity_id value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -128,24 +176,40 @@ func (v *WindowsResourceActivity) ValidateObservables() error {
 }
 
 var WindowsResourceActivityFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "actor", Type: ActorStruct, Nullable: false},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "device", Type: DeviceStruct, Nullable: false},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "start_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},

--- a/ocsf/v1_4_0/windows_service_activity.go
+++ b/ocsf/v1_4_0/windows_service_activity.go
@@ -10,6 +10,12 @@ import (
 
 type WindowsServiceActivity struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
@@ -18,6 +24,15 @@ type WindowsServiceActivity struct {
 
 	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
 	Actor Actor `json:"actor" parquet:"actor"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® Details: An array of <a target='_blank' href='https://attack.mitre.org'>MITRE ATT&CK®</a> objects describing identified tactics, techniques & sub-techniques.
+	Attacks []MITREATTCK `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>System Activity</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -31,14 +46,26 @@ type WindowsServiceActivity struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
 
 	// Device: An addressable device, computer system or host.
 	Device Device `json:"device" parquet:"device"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -49,6 +76,15 @@ type WindowsServiceActivity struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
 
@@ -58,11 +94,23 @@ type WindowsServiceActivity struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the severity_id value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -128,24 +176,40 @@ func (v *WindowsServiceActivity) ValidateObservables() error {
 }
 
 var WindowsServiceActivityFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "actor", Type: ActorStruct, Nullable: false},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "device", Type: DeviceStruct, Nullable: false},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "start_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},

--- a/ocsf/v1_5_0/account_change.go
+++ b/ocsf/v1_5_0/account_change.go
@@ -10,11 +10,29 @@ import (
 
 type AccountChange struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
+
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® and ATLAS™ Details: An array of MITRE ATT&CK® objects describing identified tactics, techniques & sub-techniques. The objects are compatible with MITRE ATLAS™ tactics, techniques & sub-techniques.
+	Attacks []MITREATTCKATLAS `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Identity & Access Management</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -28,11 +46,26 @@ type AccountChange struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
+
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -43,11 +76,23 @@ type AccountChange struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
 	// HTTP Request: Details about the underlying HTTP request.
 	HttpRequest *HTTPRequest `json:"http_request,omitempty" parquet:"http_request,optional"`
 
 	// HTTP Response: Details about the underlying HTTP response.
 	HttpResponse *HTTPResponse `json:"http_response,omitempty" parquet:"http_response,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
+	// Malware Scan Info: Describes details about the scan job that identified malware on the target system.
+	MalwareScanInfo *MalwareScanInfo `json:"malware_scan_info,omitempty" parquet:"malware_scan_info,optional"`
 
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
@@ -58,9 +103,6 @@ type AccountChange struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
-
 	// Policies: Details about the IAM policies associated with the Attach/Detach Policy activities.
 	Policies []Policy `json:"policies,omitempty" parquet:"policies,list,optional"`
 
@@ -69,6 +111,18 @@ type AccountChange struct {
 
 	// Raw Data Size: The size of the raw data which was transformed into an OCSF event, in bytes.
 	RawDataSize *int64 `json:"raw_data_size,omitempty" parquet:"raw_data_size,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the <code>severity_id</code> value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -140,26 +194,44 @@ func (v *AccountChange) ValidateObservables() error {
 }
 
 var AccountChangeFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKATLASStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
 	{Name: "http_request", Type: HTTPRequestStruct, Nullable: true},
 	{Name: "http_response", Type: HTTPResponseStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
+	{Name: "malware_scan_info", Type: MalwareScanInfoStruct, Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
 	{Name: "policies", Type: arrow.ListOf(PolicyStruct), Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "raw_data_size", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "src_endpoint", Type: NetworkEndpointStruct, Nullable: true},

--- a/ocsf/v1_5_0/admin_group_query.go
+++ b/ocsf/v1_5_0/admin_group_query.go
@@ -10,11 +10,29 @@ import (
 
 type AdminGroupQuery struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
+
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® and ATLAS™ Details: An array of MITRE ATT&CK® objects describing identified tactics, techniques & sub-techniques. The objects are compatible with MITRE ATLAS™ tactics, techniques & sub-techniques.
+	Attacks []MITREATTCKATLAS `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Discovery</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -28,11 +46,26 @@ type AdminGroupQuery struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
+
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -43,8 +76,20 @@ type AdminGroupQuery struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
 	// Group: The administrative group.
 	Group Group `json:"group" parquet:"group"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
+	// Malware Scan Info: Describes details about the scan job that identified malware on the target system.
+	MalwareScanInfo *MalwareScanInfo `json:"malware_scan_info,omitempty" parquet:"malware_scan_info,optional"`
 
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
@@ -55,8 +100,8 @@ type AdminGroupQuery struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Query Info: The search details associated with the query request.
 	QueryInfo *QueryInformation `json:"query_info,omitempty" parquet:"query_info,optional"`
@@ -72,6 +117,18 @@ type AdminGroupQuery struct {
 
 	// Raw Data Size: The size of the raw data which was transformed into an OCSF event, in bytes.
 	RawDataSize *int64 `json:"raw_data_size,omitempty" parquet:"raw_data_size,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the <code>severity_id</code> value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -137,27 +194,46 @@ func (v *AdminGroupQuery) ValidateObservables() error {
 }
 
 var AdminGroupQueryFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKATLASStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
 	{Name: "group", Type: GroupStruct, Nullable: false},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
+	{Name: "malware_scan_info", Type: MalwareScanInfoStruct, Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "query_info", Type: QueryInformationStruct, Nullable: true},
 	{Name: "query_result", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "query_result_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "raw_data_size", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "start_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},

--- a/ocsf/v1_5_0/airborne_broadcast_activity.go
+++ b/ocsf/v1_5_0/airborne_broadcast_activity.go
@@ -10,14 +10,32 @@ import (
 
 type AirborneBroadcastActivity struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
 
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
 	// Aircraft: The Aircraft object represents any aircraft or otherwise airborne asset such as an unmanned system, airplane, balloon, spacecraft, or otherwise. The Aircraft object is intended to normalized data captured or otherwise logged from active radar, passive radar, multi-spectral systems, or the Automatic Dependant Broadcast - Surveillance (ADS-B), and/or Mode S systems.
 	Aircraft *Aircraft `json:"aircraft,omitempty" parquet:"aircraft,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® and ATLAS™ Details: An array of MITRE ATT&CK® objects describing identified tactics, techniques & sub-techniques. The objects are compatible with MITRE ATLAS™ tactics, techniques & sub-techniques.
+	Attacks []MITREATTCKATLAS `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Unmanned Systems</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -31,14 +49,29 @@ type AirborneBroadcastActivity struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Connection Info: The network connection information.
 	ConnectionInfo *NetworkConnectionInformation `json:"connection_info,omitempty" parquet:"connection_info,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
+
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Destination Endpoint: The destination network endpoint for the ADS-B system, if telemetry is being remotely broadcasted.
 	DstEndpoint *NetworkEndpoint `json:"dst_endpoint,omitempty" parquet:"dst_endpoint,optional"`
@@ -52,6 +85,18 @@ type AirborneBroadcastActivity struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
+	// Malware Scan Info: Describes details about the scan job that identified malware on the target system.
+	MalwareScanInfo *MalwareScanInfo `json:"malware_scan_info,omitempty" parquet:"malware_scan_info,optional"`
+
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
 
@@ -61,8 +106,8 @@ type AirborneBroadcastActivity struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// ADS-B Protocol: The specific protocol associated with the ADS-B system. E.g. <code>ADS-B UAT</code> or <code>ADS-B ES</code>.
 	ProtocolName *string `json:"protocol_name,omitempty" parquet:"protocol_name,optional"`
@@ -75,6 +120,18 @@ type AirborneBroadcastActivity struct {
 
 	// Raw Data Size: The size of the raw data which was transformed into an OCSF event, in bytes.
 	RawDataSize *int64 `json:"raw_data_size,omitempty" parquet:"raw_data_size,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// RSSI: Recent average RSSI (signal power) measured in dbFS. This value will always be negative, e.g., <code>-87.13</code>.
 	Rssi *int32 `json:"rssi,omitempty" parquet:"rssi,optional"`
@@ -158,28 +215,47 @@ func (v *AirborneBroadcastActivity) ValidateObservables() error {
 }
 
 var AirborneBroadcastActivityFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
 	{Name: "aircraft", Type: AircraftStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKATLASStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "connection_info", Type: NetworkConnectionInformationStruct, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "dst_endpoint", Type: NetworkEndpointStruct, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
+	{Name: "malware_scan_info", Type: MalwareScanInfoStruct, Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "protocol_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "proxy_endpoint", Type: NetworkProxyEndpointStruct, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "raw_data_size", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "rssi", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},

--- a/ocsf/v1_5_0/api_activity.go
+++ b/ocsf/v1_5_0/api_activity.go
@@ -10,6 +10,12 @@ import (
 
 type APIActivity struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
@@ -21,6 +27,12 @@ type APIActivity struct {
 
 	// API Details: Describes details about a typical API (Application Programming Interface) call.
 	Api API `json:"api" parquet:"api"`
+
+	// MITRE ATT&CK® and ATLAS™ Details: An array of MITRE ATT&CK® objects describing identified tactics, techniques & sub-techniques. The objects are compatible with MITRE ATLAS™ tactics, techniques & sub-techniques.
+	Attacks []MITREATTCKATLAS `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Application Activity</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -34,11 +46,26 @@ type APIActivity struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
+
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Destination Endpoint: The network destination endpoint.
 	DstEndpoint *NetworkEndpoint `json:"dst_endpoint,omitempty" parquet:"dst_endpoint,optional"`
@@ -52,11 +79,23 @@ type APIActivity struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
 	// HTTP Request: Details about the underlying http request.
 	HttpRequest *HTTPRequest `json:"http_request,omitempty" parquet:"http_request,optional"`
 
 	// HTTP Response: Details about the underlying http response.
 	HttpResponse *HTTPResponse `json:"http_response,omitempty" parquet:"http_response,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
+	// Malware Scan Info: Describes details about the scan job that identified malware on the target system.
+	MalwareScanInfo *MalwareScanInfo `json:"malware_scan_info,omitempty" parquet:"malware_scan_info,optional"`
 
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
@@ -67,8 +106,8 @@ type APIActivity struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
@@ -78,6 +117,18 @@ type APIActivity struct {
 
 	// Resources Array: Details about resources that were affected by the activity/event.
 	Resources []ResourceDetails `json:"resources,omitempty" parquet:"resources,list,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the <code>severity_id</code> value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -143,29 +194,46 @@ func (v *APIActivity) ValidateObservables() error {
 }
 
 var APIActivityFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "actor", Type: ActorStruct, Nullable: false},
 	{Name: "api", Type: APIStruct, Nullable: false},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKATLASStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "dst_endpoint", Type: NetworkEndpointStruct, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
 	{Name: "http_request", Type: HTTPRequestStruct, Nullable: true},
 	{Name: "http_response", Type: HTTPResponseStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
+	{Name: "malware_scan_info", Type: MalwareScanInfoStruct, Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "raw_data_size", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "resources", Type: arrow.ListOf(ResourceDetailsStruct), Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "src_endpoint", Type: NetworkEndpointStruct, Nullable: false},

--- a/ocsf/v1_5_0/application_error.go
+++ b/ocsf/v1_5_0/application_error.go
@@ -10,11 +10,29 @@ import (
 
 type ApplicationError struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
+
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® and ATLAS™ Details: An array of MITRE ATT&CK® objects describing identified tactics, techniques & sub-techniques. The objects are compatible with MITRE ATLAS™ tactics, techniques & sub-techniques.
+	Attacks []MITREATTCKATLAS `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Application Activity</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -28,11 +46,26 @@ type ApplicationError struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
+
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -43,6 +76,18 @@ type ApplicationError struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
+	// Malware Scan Info: Describes details about the scan job that identified malware on the target system.
+	MalwareScanInfo *MalwareScanInfo `json:"malware_scan_info,omitempty" parquet:"malware_scan_info,optional"`
+
 	// Message: The error message as reported by the application.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
 
@@ -52,14 +97,26 @@ type ApplicationError struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
 
 	// Raw Data Size: The size of the raw data which was transformed into an OCSF event, in bytes.
 	RawDataSize *int64 `json:"raw_data_size,omitempty" parquet:"raw_data_size,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the <code>severity_id</code> value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -122,23 +179,42 @@ func (v *ApplicationError) ValidateObservables() error {
 }
 
 var ApplicationErrorFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKATLASStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
+	{Name: "malware_scan_info", Type: MalwareScanInfoStruct, Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "raw_data_size", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "start_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},

--- a/ocsf/v1_5_0/application_lifecycle.go
+++ b/ocsf/v1_5_0/application_lifecycle.go
@@ -10,14 +10,32 @@ import (
 
 type ApplicationLifecycle struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
 
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
 	// Application: The application that was affected by the lifecycle event.  This also applies to self-updating application systems.
 	App Product `json:"app" parquet:"app"`
+
+	// MITRE ATT&CK® and ATLAS™ Details: An array of MITRE ATT&CK® objects describing identified tactics, techniques & sub-techniques. The objects are compatible with MITRE ATLAS™ tactics, techniques & sub-techniques.
+	Attacks []MITREATTCKATLAS `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Application Activity</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -31,11 +49,26 @@ type ApplicationLifecycle struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
+
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -46,6 +79,18 @@ type ApplicationLifecycle struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
+	// Malware Scan Info: Describes details about the scan job that identified malware on the target system.
+	MalwareScanInfo *MalwareScanInfo `json:"malware_scan_info,omitempty" parquet:"malware_scan_info,optional"`
+
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
 
@@ -55,14 +100,26 @@ type ApplicationLifecycle struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
 
 	// Raw Data Size: The size of the raw data which was transformed into an OCSF event, in bytes.
 	RawDataSize *int64 `json:"raw_data_size,omitempty" parquet:"raw_data_size,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the <code>severity_id</code> value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -125,24 +182,43 @@ func (v *ApplicationLifecycle) ValidateObservables() error {
 }
 
 var ApplicationLifecycleFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
 	{Name: "app", Type: ProductStruct, Nullable: false},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKATLASStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
+	{Name: "malware_scan_info", Type: MalwareScanInfoStruct, Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "raw_data_size", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "start_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},

--- a/ocsf/v1_5_0/application_security_posture_finding.go
+++ b/ocsf/v1_5_0/application_security_posture_finding.go
@@ -10,14 +10,38 @@ import (
 
 type ApplicationSecurityPostureFinding struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the finding activity.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The finding activity name, as defined by the <code>activity_id</code>.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
 
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
 	// Related Application: An Application describes the details for an inventoried application as reported by an Application Security tool or other Developer-centric tooling. Applications can be defined as Kubernetes resources, Containerized resources, or application hosting-specific cloud sources such as AWS Elastic BeanStalk, AWS Lightsail, or Azure Logic Apps.
 	Application *Application `json:"application,omitempty" parquet:"application,optional"`
+
+	// Assignee: The details of the user assigned to an Incident.
+	Assignee *User `json:"assignee,omitempty" parquet:"assignee,optional"`
+
+	// Assignee Group: The details of the group assigned to an Incident.
+	AssigneeGroup *Group `json:"assignee_group,omitempty" parquet:"assignee_group,optional"`
+
+	// MITRE ATT&CK® and ATLAS™ Details: An array of MITRE ATT&CK® objects describing identified tactics, techniques & sub-techniques. The objects are compatible with MITRE ATLAS™ tactics, techniques & sub-techniques.
+	Attacks []MITREATTCKATLAS `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Findings</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -31,17 +55,32 @@ type ApplicationSecurityPostureFinding struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
-
 	// Comment: A user provided comment about the finding.
 	Comment *string `json:"comment,omitempty" parquet:"comment,optional"`
 
 	// Related Compliance: Provides compliance context to vulnerabilities and other weaknesses that are reported as part of an Application Security or Vulnerability Management tool's built-in compliance framework mapping.
 	Compliance *Compliance `json:"compliance,omitempty" parquet:"compliance,optional"`
 
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
+
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
+
+	// Device: Describes the affected device/host. It can be used in conjunction with <code>Affected Resource(s)</code>. <p> e.g. Specific details about an AWS EC2 instance, that is affected by the Finding.</p>
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -55,6 +94,30 @@ type ApplicationSecurityPostureFinding struct {
 	// Finding Information: Describes the supporting information about a generated finding.
 	FindingInfo FindingInformation `json:"finding_info" parquet:"finding_info"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Impact: The impact , normalized to the caption of the impact_id value. In the case of 'Other', it is defined by the event source.
+	Impact *string `json:"impact,omitempty" parquet:"impact,optional"`
+
+	// Impact ID: The normalized impact of the incident or finding. Per NIST, this is the magnitude of harm that can be expected to result from the consequences of unauthorized disclosure, modification, destruction, or loss of information or information system availability.
+	ImpactId *int32 `json:"impact_id,omitempty" parquet:"impact_id,optional"`
+
+	// Impact Score: The impact as an integer value of the finding, valid range 0-100.
+	ImpactScore *int32 `json:"impact_score,omitempty" parquet:"impact_score,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Suspected Breach: A determination based on analytics as to whether a potential breach was found.
+	IsSuspectedBreach *bool `json:"is_suspected_breach,omitempty" parquet:"is_suspected_breach,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
+	// Malware Scan Info: Describes details about the scan job that identified malware on the target system.
+	MalwareScanInfo *MalwareScanInfo `json:"malware_scan_info,omitempty" parquet:"malware_scan_info,optional"`
+
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
 
@@ -64,8 +127,14 @@ type ApplicationSecurityPostureFinding struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
+
+	// Priority: The priority, normalized to the caption of the priority_id value. In the case of 'Other', it is defined by the event source.
+	Priority *string `json:"priority,omitempty" parquet:"priority,optional"`
+
+	// Priority ID: The normalized priority. Priority identifies the relative importance of the incident or finding. It is a measurement of urgency.
+	PriorityId *int32 `json:"priority_id,omitempty" parquet:"priority_id,optional"`
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
@@ -79,11 +148,26 @@ type ApplicationSecurityPostureFinding struct {
 	// Affected Resources: Describes details about the resource/resources that are affected by the vulnerability/vulnerabilities.
 	Resources []ResourceDetails `json:"resources,omitempty" parquet:"resources,list,optional"`
 
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
+
 	// Severity: The event/finding severity, normalized to the caption of the <code>severity_id</code> value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
 
 	// Severity ID: <p>The normalized identifier of the event/finding severity.</p>The normalized severity is a measurement the effort and expense required to manage and resolve an event or incident. Smaller numerical values represent lower impact events, and larger numerical values represent higher impact events.
 	SeverityId int32 `json:"severity_id" parquet:"severity_id"`
+
+	// Source URL: A Url link used to access the original incident.
+	SrcUrl *string `json:"src_url,omitempty" parquet:"src_url,optional"`
 
 	// Start Time: The time of the least recent event included in the finding.
 	StartTime int64 `json:"start_time,omitempty" parquet:"start_time,timestamp_millis,timestamp(millisecond),optional"`
@@ -99,6 +183,9 @@ type ApplicationSecurityPostureFinding struct {
 
 	// Status ID: The normalized status identifier of the Finding, set by the consumer.
 	StatusId *int32 `json:"status_id,omitempty" parquet:"status_id,optional"`
+
+	// Tickets: The associated ticket(s) in the ticketing system. Each ticket contains details like ticket ID, status, etc.
+	Tickets []Ticket `json:"tickets,omitempty" parquet:"tickets,list,optional"`
 
 	// Event Time: The normalized event occurrence time or the finding creation time.
 	Time int64 `json:"time" parquet:"time,timestamp_millis,timestamp(millisecond)"`
@@ -117,6 +204,12 @@ type ApplicationSecurityPostureFinding struct {
 
 	// Vendor Attributes: The Vendor Attributes object can be used to represent values of attributes populated by the Vendor/Finding Provider. It can help distinguish between the vendor-prodvided values and consumer-updated values, of key attributes like <code>severity_id</code>.<br>The original finding producer should not populate this object. It should be populated by consuming systems that support data mutability.
 	VendorAttributes *VendorAttributes `json:"vendor_attributes,omitempty" parquet:"vendor_attributes,optional"`
+
+	// Verdict: The verdict assigned to an Incident finding.
+	Verdict *string `json:"verdict,omitempty" parquet:"verdict,optional"`
+
+	// Verdict ID: The normalized verdict of an Incident.
+	VerdictId *int32 `json:"verdict_id,omitempty" parquet:"verdict_id,optional"`
 
 	// Vulnerabilities: This object describes vulnerabilities reported in a security finding.
 	Vulnerabilities []VulnerabilityDetails `json:"vulnerabilities,omitempty" parquet:"vulnerabilities,list,optional"`
@@ -146,42 +239,73 @@ func (v *ApplicationSecurityPostureFinding) ValidateObservables() error {
 }
 
 var ApplicationSecurityPostureFindingFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
 	{Name: "application", Type: ApplicationStruct, Nullable: true},
+	{Name: "assignee", Type: UserStruct, Nullable: true},
+	{Name: "assignee_group", Type: GroupStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKATLASStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
 	{Name: "comment", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "compliance", Type: ComplianceStruct, Nullable: true},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
 	{Name: "finding_info", Type: FindingInformationStruct, Nullable: false},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "impact", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "impact_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "impact_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "is_suspected_breach", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
+	{Name: "malware_scan_info", Type: MalwareScanInfoStruct, Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
+	{Name: "priority", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "priority_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "raw_data_size", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "remediation", Type: RemediationStruct, Nullable: true},
 	{Name: "resources", Type: arrow.ListOf(ResourceDetailsStruct), Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
+	{Name: "src_url", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "start_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "status", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "status_code", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "status_detail", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "status_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "tickets", Type: arrow.ListOf(TicketStruct), Nullable: true},
 	{Name: "time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: false},
 	{Name: "timezone_offset", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "type_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "type_uid", Type: arrow.PrimitiveTypes.Int64, Nullable: false},
 	{Name: "unmapped", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "vendor_attributes", Type: VendorAttributesStruct, Nullable: true},
+	{Name: "verdict", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "verdict_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "vulnerabilities", Type: arrow.ListOf(VulnerabilityDetailsStruct), Nullable: true},
 }
 

--- a/ocsf/v1_5_0/authentication.go
+++ b/ocsf/v1_5_0/authentication.go
@@ -10,11 +10,26 @@ import (
 
 type Authentication struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
+
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® and ATLAS™ Details: An array of MITRE ATT&CK® objects describing identified tactics, techniques & sub-techniques. The objects are compatible with MITRE ATLAS™ tactics, techniques & sub-techniques.
+	Attacks []MITREATTCKATLAS `json:"attacks,omitempty" parquet:"attacks,list,optional"`
 
 	// Authentication Factors: Describes a category of methods used for identity verification in an authentication attempt.
 	AuthFactors []AuthenticationFactor `json:"auth_factors,omitempty" parquet:"auth_factors,list,optional"`
@@ -27,6 +42,9 @@ type Authentication struct {
 
 	// Authentication Token: The authentication token, ticket, or assertion, e.g. <code>Kerberos</code>, <code>OIDC</code>, <code>SAML</code>.
 	AuthenticationToken *AuthenticationToken `json:"authentication_token,omitempty" parquet:"authentication_token,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Identity & Access Management</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -43,11 +61,26 @@ type Authentication struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
+
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Destination Endpoint: The endpoint to which the authentication was targeted.
 	DstEndpoint *NetworkEndpoint `json:"dst_endpoint,omitempty" parquet:"dst_endpoint,optional"`
@@ -61,11 +94,17 @@ type Authentication struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
 	// HTTP Request: Details about the underlying HTTP request.
 	HttpRequest *HTTPRequest `json:"http_request,omitempty" parquet:"http_request,optional"`
 
 	// HTTP Response: Details about the underlying HTTP response.
 	HttpResponse *HTTPResponse `json:"http_response,omitempty" parquet:"http_response,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
 
 	// Cleartext Credentials: Indicates whether the credentials were passed in clear text.<p><b>Note:</b> True if the credentials were passed in a clear text protocol such as FTP or TELNET, or if Windows detected that a user's logon password was passed to the authentication package in clear text.</p>
 	IsCleartext *bool `json:"is_cleartext,omitempty" parquet:"is_cleartext,optional"`
@@ -88,6 +127,12 @@ type Authentication struct {
 	// Logon Type ID: The normalized logon type identifier.
 	LogonTypeId *int32 `json:"logon_type_id,omitempty" parquet:"logon_type_id,optional"`
 
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
+	// Malware Scan Info: Describes details about the scan job that identified malware on the target system.
+	MalwareScanInfo *MalwareScanInfo `json:"malware_scan_info,omitempty" parquet:"malware_scan_info,optional"`
+
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
 
@@ -97,14 +142,26 @@ type Authentication struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
 
 	// Raw Data Size: The size of the raw data which was transformed into an OCSF event, in bytes.
 	RawDataSize *int64 `json:"raw_data_size,omitempty" parquet:"raw_data_size,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Service: The service or gateway to which the user or process is being authenticated
 	Service *Service `json:"service,omitempty" parquet:"service,optional"`
@@ -179,25 +236,38 @@ func (v *Authentication) ValidateObservables() error {
 }
 
 var AuthenticationFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKATLASStruct), Nullable: true},
 	{Name: "auth_factors", Type: arrow.ListOf(AuthenticationFactorStruct), Nullable: true},
 	{Name: "auth_protocol", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "auth_protocol_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "authentication_token", Type: AuthenticationTokenStruct, Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "certificate", Type: DigitalCertificateStruct, Nullable: true},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "dst_endpoint", Type: NetworkEndpointStruct, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
 	{Name: "http_request", Type: HTTPRequestStruct, Nullable: true},
 	{Name: "http_response", Type: HTTPResponseStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
 	{Name: "is_cleartext", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
 	{Name: "is_mfa", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
 	{Name: "is_new_logon", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
@@ -205,12 +275,18 @@ var AuthenticationFields = []arrow.Field{
 	{Name: "logon_process", Type: ProcessStruct, Nullable: true},
 	{Name: "logon_type", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "logon_type_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
+	{Name: "malware_scan_info", Type: MalwareScanInfoStruct, Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "raw_data_size", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "service", Type: ServiceStruct, Nullable: true},
 	{Name: "session", Type: SessionStruct, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},

--- a/ocsf/v1_5_0/authorize_session.go
+++ b/ocsf/v1_5_0/authorize_session.go
@@ -10,11 +10,29 @@ import (
 
 type AuthorizeSession struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
+
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® and ATLAS™ Details: An array of MITRE ATT&CK® objects describing identified tactics, techniques & sub-techniques. The objects are compatible with MITRE ATLAS™ tactics, techniques & sub-techniques.
+	Attacks []MITREATTCKATLAS `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Identity & Access Management</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -28,11 +46,26 @@ type AuthorizeSession struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
+
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Destination Endpoint: The Endpoint for which the user session was targeted.
 	DstEndpoint *NetworkEndpoint `json:"dst_endpoint,omitempty" parquet:"dst_endpoint,optional"`
@@ -46,11 +79,26 @@ type AuthorizeSession struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Group: Group that was assigned to the new user session.
+	Group *Group `json:"group,omitempty" parquet:"group,optional"`
+
 	// HTTP Request: Details about the underlying HTTP request.
 	HttpRequest *HTTPRequest `json:"http_request,omitempty" parquet:"http_request,optional"`
 
 	// HTTP Response: Details about the underlying HTTP response.
 	HttpResponse *HTTPResponse `json:"http_response,omitempty" parquet:"http_response,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
+	// Malware Scan Info: Describes details about the scan job that identified malware on the target system.
+	MalwareScanInfo *MalwareScanInfo `json:"malware_scan_info,omitempty" parquet:"malware_scan_info,optional"`
 
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
@@ -61,8 +109,8 @@ type AuthorizeSession struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Privileges: The list of sensitive privileges, assigned to the new user session.
 	Privileges []string `json:"privileges,omitempty" parquet:"privileges,list,optional"`
@@ -72,6 +120,18 @@ type AuthorizeSession struct {
 
 	// Raw Data Size: The size of the raw data which was transformed into an OCSF event, in bytes.
 	RawDataSize *int64 `json:"raw_data_size,omitempty" parquet:"raw_data_size,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Session: The user session with the assigned privileges.
 	Session *Session `json:"session,omitempty" parquet:"session,optional"`
@@ -143,27 +203,47 @@ func (v *AuthorizeSession) ValidateObservables() error {
 }
 
 var AuthorizeSessionFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKATLASStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "dst_endpoint", Type: NetworkEndpointStruct, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "group", Type: GroupStruct, Nullable: true},
 	{Name: "http_request", Type: HTTPRequestStruct, Nullable: true},
 	{Name: "http_response", Type: HTTPResponseStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
+	{Name: "malware_scan_info", Type: MalwareScanInfoStruct, Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "privileges", Type: arrow.ListOf(arrow.BinaryTypes.String), Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "raw_data_size", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "session", Type: SessionStruct, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},

--- a/ocsf/v1_5_0/base_event.go
+++ b/ocsf/v1_5_0/base_event.go
@@ -10,11 +10,29 @@ import (
 
 type BaseEvent struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
+
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® and ATLAS™ Details: An array of MITRE ATT&CK® objects describing identified tactics, techniques & sub-techniques. The objects are compatible with MITRE ATLAS™ tactics, techniques & sub-techniques.
+	Attacks []MITREATTCKATLAS `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -28,11 +46,26 @@ type BaseEvent struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
+
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -43,6 +76,18 @@ type BaseEvent struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
+	// Malware Scan Info: Describes details about the scan job that identified malware on the target system.
+	MalwareScanInfo *MalwareScanInfo `json:"malware_scan_info,omitempty" parquet:"malware_scan_info,optional"`
+
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
 
@@ -52,14 +97,26 @@ type BaseEvent struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
 
 	// Raw Data Size: The size of the raw data which was transformed into an OCSF event, in bytes.
 	RawDataSize *int64 `json:"raw_data_size,omitempty" parquet:"raw_data_size,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the <code>severity_id</code> value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -122,23 +179,42 @@ func (v *BaseEvent) ValidateObservables() error {
 }
 
 var BaseEventFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKATLASStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
+	{Name: "malware_scan_info", Type: MalwareScanInfoStruct, Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "raw_data_size", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "start_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},

--- a/ocsf/v1_5_0/cloud_resources_inventory_info.go
+++ b/ocsf/v1_5_0/cloud_resources_inventory_info.go
@@ -10,11 +10,29 @@ import (
 
 type CloudResourcesInventoryInfo struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
+
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® and ATLAS™ Details: An array of MITRE ATT&CK® objects describing identified tactics, techniques & sub-techniques. The objects are compatible with MITRE ATLAS™ tactics, techniques & sub-techniques.
+	Attacks []MITREATTCKATLAS `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Discovery</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -28,6 +46,15 @@ type CloudResourcesInventoryInfo struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
+
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
 
@@ -36,6 +63,15 @@ type CloudResourcesInventoryInfo struct {
 
 	// Databucket: A cloud-based data bucket or other object storage discovered by an inventory process.
 	Databucket *Databucket `json:"databucket,omitempty" parquet:"databucket,optional"`
+
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -46,8 +82,20 @@ type CloudResourcesInventoryInfo struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
 	// Identity Provider: The Identity Provider that is being discovered by an inventory process, or that is related to the cloud resource(s) being discovered by an inventory process.
 	Idp *IdentityProvider `json:"idp,omitempty" parquet:"idp,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
+	// Malware Scan Info: Describes details about the scan job that identified malware on the target system.
+	MalwareScanInfo *MalwareScanInfo `json:"malware_scan_info,omitempty" parquet:"malware_scan_info,optional"`
 
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
@@ -58,8 +106,8 @@ type CloudResourcesInventoryInfo struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
@@ -72,6 +120,18 @@ type CloudResourcesInventoryInfo struct {
 
 	// Cloud Resources: The cloud resource(s) that are being discovered by an inventory process. Use this object if there is not a direct object match in the class.
 	Resources []ResourceDetails `json:"resources,omitempty" parquet:"resources,list,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the <code>severity_id</code> value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -137,27 +197,47 @@ func (v *CloudResourcesInventoryInfo) ValidateObservables() error {
 }
 
 var CloudResourcesInventoryInfoFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKATLASStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "database", Type: DatabaseStruct, Nullable: true},
 	{Name: "databucket", Type: DatabucketStruct, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
 	{Name: "idp", Type: IdentityProviderStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
+	{Name: "malware_scan_info", Type: MalwareScanInfoStruct, Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "raw_data_size", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "region", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "resources", Type: arrow.ListOf(ResourceDetailsStruct), Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "start_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},

--- a/ocsf/v1_5_0/compliance_finding.go
+++ b/ocsf/v1_5_0/compliance_finding.go
@@ -10,11 +10,35 @@ import (
 
 type ComplianceFinding struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the finding activity.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The finding activity name, as defined by the <code>activity_id</code>.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
+
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// Assignee: The details of the user assigned to an Incident.
+	Assignee *User `json:"assignee,omitempty" parquet:"assignee,optional"`
+
+	// Assignee Group: The details of the group assigned to an Incident.
+	AssigneeGroup *Group `json:"assignee_group,omitempty" parquet:"assignee_group,optional"`
+
+	// MITRE ATT&CK® and ATLAS™ Details: An array of MITRE ATT&CK® objects describing identified tactics, techniques & sub-techniques. The objects are compatible with MITRE ATLAS™ tactics, techniques & sub-techniques.
+	Attacks []MITREATTCKATLAS `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Findings</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -28,17 +52,32 @@ type ComplianceFinding struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
-
 	// Comment: A user provided comment about the finding.
 	Comment *string `json:"comment,omitempty" parquet:"comment,optional"`
 
 	// Compliance: The compliance object provides context to compliance findings (e.g., a check against a specific regulatory or best practice framework such as CIS, NIST etc.) and contains compliance related details.
 	Compliance Compliance `json:"compliance" parquet:"compliance"`
 
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
+
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
+
+	// Device: Describes the affected device/host. It can be used in conjunction with <code>Affected Resource(s)</code>. <p> e.g. Specific details about an AWS EC2 instance, that is affected by the Finding.</p>
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -55,6 +94,30 @@ type ComplianceFinding struct {
 	// Finding Information: Describes the supporting information about a generated finding.
 	FindingInfo FindingInformation `json:"finding_info" parquet:"finding_info"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Impact: The impact , normalized to the caption of the impact_id value. In the case of 'Other', it is defined by the event source.
+	Impact *string `json:"impact,omitempty" parquet:"impact,optional"`
+
+	// Impact ID: The normalized impact of the incident or finding. Per NIST, this is the magnitude of harm that can be expected to result from the consequences of unauthorized disclosure, modification, destruction, or loss of information or information system availability.
+	ImpactId *int32 `json:"impact_id,omitempty" parquet:"impact_id,optional"`
+
+	// Impact Score: The impact as an integer value of the finding, valid range 0-100.
+	ImpactScore *int32 `json:"impact_score,omitempty" parquet:"impact_score,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Suspected Breach: A determination based on analytics as to whether a potential breach was found.
+	IsSuspectedBreach *bool `json:"is_suspected_breach,omitempty" parquet:"is_suspected_breach,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
+	// Malware Scan Info: Describes details about the scan job that identified malware on the target system.
+	MalwareScanInfo *MalwareScanInfo `json:"malware_scan_info,omitempty" parquet:"malware_scan_info,optional"`
+
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
 
@@ -64,8 +127,14 @@ type ComplianceFinding struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
+
+	// Priority: The priority, normalized to the caption of the priority_id value. In the case of 'Other', it is defined by the event source.
+	Priority *string `json:"priority,omitempty" parquet:"priority,optional"`
+
+	// Priority ID: The normalized priority. Priority identifies the relative importance of the incident or finding. It is a measurement of urgency.
+	PriorityId *int32 `json:"priority_id,omitempty" parquet:"priority_id,optional"`
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
@@ -79,11 +148,26 @@ type ComplianceFinding struct {
 	// Resources Array: Describes details about the resource/resouces that are the subject of the compliance check.
 	Resources []ResourceDetails `json:"resources,omitempty" parquet:"resources,list,optional"`
 
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
+
 	// Severity: The event/finding severity, normalized to the caption of the <code>severity_id</code> value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
 
 	// Severity ID: <p>The normalized identifier of the event/finding severity.</p>The normalized severity is a measurement the effort and expense required to manage and resolve an event or incident. Smaller numerical values represent lower impact events, and larger numerical values represent higher impact events.
 	SeverityId int32 `json:"severity_id" parquet:"severity_id"`
+
+	// Source URL: A Url link used to access the original incident.
+	SrcUrl *string `json:"src_url,omitempty" parquet:"src_url,optional"`
 
 	// Start Time: The time of the least recent event included in the finding.
 	StartTime int64 `json:"start_time,omitempty" parquet:"start_time,timestamp_millis,timestamp(millisecond),optional"`
@@ -99,6 +183,9 @@ type ComplianceFinding struct {
 
 	// Status ID: The normalized status identifier of the Finding, set by the consumer.
 	StatusId *int32 `json:"status_id,omitempty" parquet:"status_id,optional"`
+
+	// Tickets: The associated ticket(s) in the ticketing system. Each ticket contains details like ticket ID, status, etc.
+	Tickets []Ticket `json:"tickets,omitempty" parquet:"tickets,list,optional"`
 
 	// Event Time: The normalized event occurrence time or the finding creation time.
 	Time int64 `json:"time" parquet:"time,timestamp_millis,timestamp(millisecond)"`
@@ -117,6 +204,12 @@ type ComplianceFinding struct {
 
 	// Vendor Attributes: The Vendor Attributes object can be used to represent values of attributes populated by the Vendor/Finding Provider. It can help distinguish between the vendor-prodvided values and consumer-updated values, of key attributes like <code>severity_id</code>.<br>The original finding producer should not populate this object. It should be populated by consuming systems that support data mutability.
 	VendorAttributes *VendorAttributes `json:"vendor_attributes,omitempty" parquet:"vendor_attributes,optional"`
+
+	// Verdict: The verdict assigned to an Incident finding.
+	Verdict *string `json:"verdict,omitempty" parquet:"verdict,optional"`
+
+	// Verdict ID: The normalized verdict of an Incident.
+	VerdictId *int32 `json:"verdict_id,omitempty" parquet:"verdict_id,optional"`
 }
 
 func (v *ComplianceFinding) Observable() (*int, string) {
@@ -143,42 +236,73 @@ func (v *ComplianceFinding) ValidateObservables() error {
 }
 
 var ComplianceFindingFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "assignee", Type: UserStruct, Nullable: true},
+	{Name: "assignee_group", Type: GroupStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKATLASStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
 	{Name: "comment", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "compliance", Type: ComplianceStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
 	{Name: "evidences", Type: arrow.ListOf(EvidenceArtifactsStruct), Nullable: true},
 	{Name: "finding_info", Type: FindingInformationStruct, Nullable: false},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "impact", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "impact_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "impact_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "is_suspected_breach", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
+	{Name: "malware_scan_info", Type: MalwareScanInfoStruct, Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
+	{Name: "priority", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "priority_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "raw_data_size", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "remediation", Type: RemediationStruct, Nullable: true},
 	{Name: "resources", Type: arrow.ListOf(ResourceDetailsStruct), Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
+	{Name: "src_url", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "start_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "status", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "status_code", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "status_detail", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "status_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "tickets", Type: arrow.ListOf(TicketStruct), Nullable: true},
 	{Name: "time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: false},
 	{Name: "timezone_offset", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "type_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "type_uid", Type: arrow.PrimitiveTypes.Int64, Nullable: false},
 	{Name: "unmapped", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "vendor_attributes", Type: VendorAttributesStruct, Nullable: true},
+	{Name: "verdict", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "verdict_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 }
 
 var ComplianceFindingStruct = arrow.StructOf(ComplianceFindingFields...)

--- a/ocsf/v1_5_0/config_state.go
+++ b/ocsf/v1_5_0/config_state.go
@@ -10,14 +10,32 @@ import (
 
 type DeviceConfigState struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
 
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
 	// Related Assessments: A list of assessments associated with the device.
 	Assessments []Assessment `json:"assessments,omitempty" parquet:"assessments,list,optional"`
+
+	// MITRE ATT&CK® and ATLAS™ Details: An array of MITRE ATT&CK® objects describing identified tactics, techniques & sub-techniques. The objects are compatible with MITRE ATLAS™ tactics, techniques & sub-techniques.
+	Attacks []MITREATTCKATLAS `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Discovery</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -31,14 +49,26 @@ type DeviceConfigState struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
 
 	// Device: The device that is being discovered by an inventory process.
 	Device Device `json:"device" parquet:"device"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -49,6 +79,18 @@ type DeviceConfigState struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
+	// Malware Scan Info: Describes details about the scan job that identified malware on the target system.
+	MalwareScanInfo *MalwareScanInfo `json:"malware_scan_info,omitempty" parquet:"malware_scan_info,optional"`
+
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
 
@@ -58,14 +100,26 @@ type DeviceConfigState struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
 
 	// Raw Data Size: The size of the raw data which was transformed into an OCSF event, in bytes.
 	RawDataSize *int64 `json:"raw_data_size,omitempty" parquet:"raw_data_size,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the <code>severity_id</code> value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -128,25 +182,43 @@ func (v *DeviceConfigState) ValidateObservables() error {
 }
 
 var DeviceConfigStateFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
 	{Name: "assessments", Type: arrow.ListOf(AssessmentStruct), Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKATLASStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "device", Type: DeviceStruct, Nullable: false},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
+	{Name: "malware_scan_info", Type: MalwareScanInfoStruct, Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "raw_data_size", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "start_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},

--- a/ocsf/v1_5_0/data_security_finding.go
+++ b/ocsf/v1_5_0/data_security_finding.go
@@ -10,11 +10,35 @@ import (
 
 type DataSecurityFinding struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the Data Security Finding activity.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The Data Security finding activity name, as defined by the <code>activity_id</code>.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
+
+	// Actor: Describes details about the actor implicated in the data security finding. Either an actor that owns a particular digital file or information store, or an actor which accessed classified or sensitive data.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// Assignee: The details of the user assigned to an Incident.
+	Assignee *User `json:"assignee,omitempty" parquet:"assignee,optional"`
+
+	// Assignee Group: The details of the group assigned to an Incident.
+	AssigneeGroup *Group `json:"assignee_group,omitempty" parquet:"assignee_group,optional"`
+
+	// MITRE ATT&CK® and ATLAS™ Details: An array of MITRE ATT&CK® objects describing identified tactics, techniques & sub-techniques. The objects are compatible with MITRE ATLAS™ tactics, techniques & sub-techniques.
+	Attacks []MITREATTCKATLAS `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Findings</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -28,11 +52,17 @@ type DataSecurityFinding struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
-
 	// Comment: A user provided comment about the finding.
 	Comment *string `json:"comment,omitempty" parquet:"comment,optional"`
+
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
@@ -45,6 +75,15 @@ type DataSecurityFinding struct {
 
 	// Databucket: Describes the databucket where classified or sensitive data is stored in, or was accessed from. The data bucket object is a basic container that holds data, typically organized through the use of data partitions.
 	Databucket *Databucket `json:"databucket,omitempty" parquet:"databucket,optional"`
+
+	// Device: Describes the device where classified or sensitive data is stored in, or was accessed from.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Destination Endpoint: Describes the endpoint where classified or sensitive data is stored in, or was accessed from.
 	DstEndpoint *NetworkEndpoint `json:"dst_endpoint,omitempty" parquet:"dst_endpoint,optional"`
@@ -64,6 +103,30 @@ type DataSecurityFinding struct {
 	// Finding Information: Describes the supporting information about a generated finding.
 	FindingInfo FindingInformation `json:"finding_info" parquet:"finding_info"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Impact: The impact , normalized to the caption of the impact_id value. In the case of 'Other', it is defined by the event source.
+	Impact *string `json:"impact,omitempty" parquet:"impact,optional"`
+
+	// Impact ID: The normalized impact of the incident or finding. Per NIST, this is the magnitude of harm that can be expected to result from the consequences of unauthorized disclosure, modification, destruction, or loss of information or information system availability.
+	ImpactId *int32 `json:"impact_id,omitempty" parquet:"impact_id,optional"`
+
+	// Impact Score: The impact as an integer value of the finding, valid range 0-100.
+	ImpactScore *int32 `json:"impact_score,omitempty" parquet:"impact_score,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. For example, an <code>activity_id</code> of 'Create' could constitute an alertable signal and the value would be <code>true</code>, while 'Close' likely would not and either omit the attribute or set its value to <code>false</code>.  Note that other events with the <code>security_control</code> profile may also be deemed alertable signals and may also carry <code>is_alert = true</code> attributes.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Suspected Breach: A determination based on analytics as to whether a potential breach was found.
+	IsSuspectedBreach *bool `json:"is_suspected_breach,omitempty" parquet:"is_suspected_breach,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
+	// Malware Scan Info: Describes details about the scan job that identified malware on the target system.
+	MalwareScanInfo *MalwareScanInfo `json:"malware_scan_info,omitempty" parquet:"malware_scan_info,optional"`
+
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
 
@@ -73,8 +136,14 @@ type DataSecurityFinding struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
+
+	// Priority: The priority, normalized to the caption of the priority_id value. In the case of 'Other', it is defined by the event source.
+	Priority *string `json:"priority,omitempty" parquet:"priority,optional"`
+
+	// Priority ID: The normalized priority. Priority identifies the relative importance of the incident or finding. It is a measurement of urgency.
+	PriorityId *int32 `json:"priority_id,omitempty" parquet:"priority_id,optional"`
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
@@ -85,6 +154,18 @@ type DataSecurityFinding struct {
 	// Additional Resources: Describes details about additional resources, where classified or sensitive data is stored in, or was accessed from. <p> You can populate this object, if the specific resource type objects available in the class (<code>database, databucket, table, file</code>) aren't sufficient; OR <br> You can also choose to duplicate <code>uid, name</code> of the specific resources objects, for a consistent access to resource uids across all findings.
 	Resources []ResourceDetails `json:"resources,omitempty" parquet:"resources,list,optional"`
 
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
+
 	// Severity: The event/finding severity, normalized to the caption of the <code>severity_id</code> value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
 
@@ -93,6 +174,9 @@ type DataSecurityFinding struct {
 
 	// Source Endpoint: Details about the source endpoint where classified or sensitive data was accessed from.
 	SrcEndpoint *NetworkEndpoint `json:"src_endpoint,omitempty" parquet:"src_endpoint,optional"`
+
+	// Source URL: A Url link used to access the original incident.
+	SrcUrl *string `json:"src_url,omitempty" parquet:"src_url,optional"`
 
 	// Start Time: The time of the least recent event included in the finding.
 	StartTime int64 `json:"start_time,omitempty" parquet:"start_time,timestamp_millis,timestamp(millisecond),optional"`
@@ -112,6 +196,9 @@ type DataSecurityFinding struct {
 	// Table: Describes the table where classified or sensitive data is stored in, or was accessed from. The table object represents a table within a structured relational database, warehouse, lake, or similar.
 	Table *Table `json:"table,omitempty" parquet:"table,optional"`
 
+	// Tickets: The associated ticket(s) in the ticketing system. Each ticket contains details like ticket ID, status, etc.
+	Tickets []Ticket `json:"tickets,omitempty" parquet:"tickets,list,optional"`
+
 	// Event Time: The normalized event occurrence time or the finding creation time.
 	Time int64 `json:"time" parquet:"time,timestamp_millis,timestamp(millisecond)"`
 
@@ -129,6 +216,12 @@ type DataSecurityFinding struct {
 
 	// Vendor Attributes: The Vendor Attributes object can be used to represent values of attributes populated by the Vendor/Finding Provider. It can help distinguish between the vendor-prodvided values and consumer-updated values, of key attributes like <code>severity_id</code>.<br>The original finding producer should not populate this object. It should be populated by consuming systems that support data mutability.
 	VendorAttributes *VendorAttributes `json:"vendor_attributes,omitempty" parquet:"vendor_attributes,optional"`
+
+	// Verdict: The verdict assigned to an Incident finding.
+	Verdict *string `json:"verdict,omitempty" parquet:"verdict,optional"`
+
+	// Verdict ID: The normalized verdict of an Incident.
+	VerdictId *int32 `json:"verdict_id,omitempty" parquet:"verdict_id,optional"`
 }
 
 func (v *DataSecurityFinding) Observable() (*int, string) {
@@ -155,46 +248,77 @@ func (v *DataSecurityFinding) ValidateObservables() error {
 }
 
 var DataSecurityFindingFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "assignee", Type: UserStruct, Nullable: true},
+	{Name: "assignee_group", Type: GroupStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKATLASStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
 	{Name: "comment", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "data_security", Type: DataSecurityStruct, Nullable: true},
 	{Name: "database", Type: DatabaseStruct, Nullable: true},
 	{Name: "databucket", Type: DatabucketStruct, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "dst_endpoint", Type: NetworkEndpointStruct, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
 	{Name: "file", Type: FileStruct, Nullable: true},
 	{Name: "finding_info", Type: FindingInformationStruct, Nullable: false},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "impact", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "impact_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "impact_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "is_suspected_breach", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
+	{Name: "malware_scan_info", Type: MalwareScanInfoStruct, Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
+	{Name: "priority", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "priority_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "raw_data_size", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "resources", Type: arrow.ListOf(ResourceDetailsStruct), Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "src_endpoint", Type: NetworkEndpointStruct, Nullable: true},
+	{Name: "src_url", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "start_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "status", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "status_code", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "status_detail", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "status_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "table", Type: TableStruct, Nullable: true},
+	{Name: "tickets", Type: arrow.ListOf(TicketStruct), Nullable: true},
 	{Name: "time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: false},
 	{Name: "timezone_offset", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "type_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "type_uid", Type: arrow.PrimitiveTypes.Int64, Nullable: false},
 	{Name: "unmapped", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "vendor_attributes", Type: VendorAttributesStruct, Nullable: true},
+	{Name: "verdict", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "verdict_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 }
 
 var DataSecurityFindingStruct = arrow.StructOf(DataSecurityFindingFields...)

--- a/ocsf/v1_5_0/datastore_activity.go
+++ b/ocsf/v1_5_0/datastore_activity.go
@@ -10,6 +10,12 @@ import (
 
 type DatastoreActivity struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
@@ -18,6 +24,15 @@ type DatastoreActivity struct {
 
 	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
 	Actor Actor `json:"actor" parquet:"actor"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® and ATLAS™ Details: An array of MITRE ATT&CK® objects describing identified tactics, techniques & sub-techniques. The objects are compatible with MITRE ATLAS™ tactics, techniques & sub-techniques.
+	Attacks []MITREATTCKATLAS `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Application Activity</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -31,8 +46,14 @@ type DatastoreActivity struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
@@ -42,6 +63,15 @@ type DatastoreActivity struct {
 
 	// Databucket: The data bucket object is a basic container that holds data, typically organized through the use of data partitions.
 	Databucket *Databucket `json:"databucket,omitempty" parquet:"databucket,optional"`
+
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Destination Endpoint: Details about the endpoint hosting the datastore application or service.
 	DstEndpoint *NetworkEndpoint `json:"dst_endpoint,omitempty" parquet:"dst_endpoint,optional"`
@@ -55,11 +85,23 @@ type DatastoreActivity struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
 	// HTTP Request: Details about the underlying http request.
 	HttpRequest *HTTPRequest `json:"http_request,omitempty" parquet:"http_request,optional"`
 
 	// HTTP Response: Details about the underlying http response.
 	HttpResponse *HTTPResponse `json:"http_response,omitempty" parquet:"http_response,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
+	// Malware Scan Info: Describes details about the scan job that identified malware on the target system.
+	MalwareScanInfo *MalwareScanInfo `json:"malware_scan_info,omitempty" parquet:"malware_scan_info,optional"`
 
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
@@ -70,8 +112,8 @@ type DatastoreActivity struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Query Info: The query info object holds information related to data access within a datastore. To access, manipulate, delete, or retrieve data from a datastore, a database query must be written using a specific syntax.
 	QueryInfo *QueryInformation `json:"query_info,omitempty" parquet:"query_info,optional"`
@@ -81,6 +123,18 @@ type DatastoreActivity struct {
 
 	// Raw Data Size: The size of the raw data which was transformed into an OCSF event, in bytes.
 	RawDataSize *int64 `json:"raw_data_size,omitempty" parquet:"raw_data_size,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the <code>severity_id</code> value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -155,30 +209,48 @@ func (v *DatastoreActivity) ValidateObservables() error {
 }
 
 var DatastoreActivityFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "actor", Type: ActorStruct, Nullable: false},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKATLASStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "database", Type: DatabaseStruct, Nullable: true},
 	{Name: "databucket", Type: DatabucketStruct, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "dst_endpoint", Type: NetworkEndpointStruct, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
 	{Name: "http_request", Type: HTTPRequestStruct, Nullable: true},
 	{Name: "http_response", Type: HTTPResponseStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
+	{Name: "malware_scan_info", Type: MalwareScanInfoStruct, Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "query_info", Type: QueryInformationStruct, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "raw_data_size", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "src_endpoint", Type: NetworkEndpointStruct, Nullable: false},

--- a/ocsf/v1_5_0/detection_finding.go
+++ b/ocsf/v1_5_0/detection_finding.go
@@ -10,14 +10,38 @@ import (
 
 type DetectionFinding struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the finding activity.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The finding activity name, as defined by the <code>activity_id</code>.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
 
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
 	// Anomaly Analyses: Describes baseline information about normal activity patterns, along with any detected deviations or anomalies that triggered this finding.
 	AnomalyAnalyses []AnomalyAnalysis `json:"anomaly_analyses,omitempty" parquet:"anomaly_analyses,list,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// Assignee: The details of the user assigned to an Incident.
+	Assignee *User `json:"assignee,omitempty" parquet:"assignee,optional"`
+
+	// Assignee Group: The details of the group assigned to an Incident.
+	AssigneeGroup *Group `json:"assignee_group,omitempty" parquet:"assignee_group,optional"`
+
+	// MITRE ATT&CK® and ATLAS™ Details: An array of MITRE ATT&CK® objects describing identified tactics, techniques & sub-techniques. The objects are compatible with MITRE ATLAS™ tactics, techniques & sub-techniques.
+	Attacks []MITREATTCKATLAS `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Findings</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -31,14 +55,29 @@ type DetectionFinding struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
-
 	// Comment: A user provided comment about the finding.
 	Comment *string `json:"comment,omitempty" parquet:"comment,optional"`
 
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
+
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
+
+	// Device: Describes the affected device/host. It can be used in conjunction with <code>Affected Resource(s)</code>. <p> e.g. Specific details about an AWS EC2 instance, that is affected by the Finding.</p>
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -55,6 +94,30 @@ type DetectionFinding struct {
 	// Finding Information: Describes the supporting information about a generated finding.
 	FindingInfo FindingInformation `json:"finding_info" parquet:"finding_info"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Impact: The impact , normalized to the caption of the impact_id value. In the case of 'Other', it is defined by the event source.
+	Impact *string `json:"impact,omitempty" parquet:"impact,optional"`
+
+	// Impact ID: The normalized impact of the incident or finding. Per NIST, this is the magnitude of harm that can be expected to result from the consequences of unauthorized disclosure, modification, destruction, or loss of information or information system availability.
+	ImpactId *int32 `json:"impact_id,omitempty" parquet:"impact_id,optional"`
+
+	// Impact Score: The impact as an integer value of the finding, valid range 0-100.
+	ImpactScore *int32 `json:"impact_score,omitempty" parquet:"impact_score,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. For example, an <code>activity_id</code> of 'Create' could constitute an alertable signal and the value would be <code>true</code>, while 'Close' likely would not and either omit the attribute or set its value to <code>false</code>.  Note that other events with the <code>security_control</code> profile may also be deemed alertable signals and may also carry <code>is_alert = true</code> attributes.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Suspected Breach: A determination based on analytics as to whether a potential breach was found.
+	IsSuspectedBreach *bool `json:"is_suspected_breach,omitempty" parquet:"is_suspected_breach,optional"`
+
+	// Malware: Describes malware reported in a Detection Finding.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
+	// Malware Scan Info: Describes details about malware scan job that triggered this Detection Finding.
+	MalwareScanInfo *MalwareScanInfo `json:"malware_scan_info,omitempty" parquet:"malware_scan_info,optional"`
+
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
 
@@ -64,8 +127,14 @@ type DetectionFinding struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
+
+	// Priority: The priority, normalized to the caption of the priority_id value. In the case of 'Other', it is defined by the event source.
+	Priority *string `json:"priority,omitempty" parquet:"priority,optional"`
+
+	// Priority ID: The normalized priority. Priority identifies the relative importance of the incident or finding. It is a measurement of urgency.
+	PriorityId *int32 `json:"priority_id,omitempty" parquet:"priority_id,optional"`
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
@@ -79,11 +148,26 @@ type DetectionFinding struct {
 	// Affected Resources: Describes details about resources that were the target of the activity that triggered the finding.
 	Resources []ResourceDetails `json:"resources,omitempty" parquet:"resources,list,optional"`
 
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
+
 	// Severity: The event/finding severity, normalized to the caption of the <code>severity_id</code> value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
 
 	// Severity ID: <p>The normalized identifier of the event/finding severity.</p>The normalized severity is a measurement the effort and expense required to manage and resolve an event or incident. Smaller numerical values represent lower impact events, and larger numerical values represent higher impact events.
 	SeverityId int32 `json:"severity_id" parquet:"severity_id"`
+
+	// Source URL: A Url link used to access the original incident.
+	SrcUrl *string `json:"src_url,omitempty" parquet:"src_url,optional"`
 
 	// Start Time: The time of the least recent event included in the finding.
 	StartTime int64 `json:"start_time,omitempty" parquet:"start_time,timestamp_millis,timestamp(millisecond),optional"`
@@ -99,6 +183,9 @@ type DetectionFinding struct {
 
 	// Status ID: The normalized status identifier of the Finding, set by the consumer.
 	StatusId *int32 `json:"status_id,omitempty" parquet:"status_id,optional"`
+
+	// Tickets: The associated ticket(s) in the ticketing system. Each ticket contains details like ticket ID, status, etc.
+	Tickets []Ticket `json:"tickets,omitempty" parquet:"tickets,list,optional"`
 
 	// Event Time: The normalized event occurrence time or the finding creation time.
 	Time int64 `json:"time" parquet:"time,timestamp_millis,timestamp(millisecond)"`
@@ -117,6 +204,12 @@ type DetectionFinding struct {
 
 	// Vendor Attributes: The Vendor Attributes object can be used to represent values of attributes populated by the Vendor/Finding Provider. It can help distinguish between the vendor-prodvided values and consumer-updated values, of key attributes like <code>severity_id</code>.<br>The original finding producer should not populate this object. It should be populated by consuming systems that support data mutability.
 	VendorAttributes *VendorAttributes `json:"vendor_attributes,omitempty" parquet:"vendor_attributes,optional"`
+
+	// Verdict: The verdict assigned to an Incident finding.
+	Verdict *string `json:"verdict,omitempty" parquet:"verdict,optional"`
+
+	// Verdict ID: The normalized verdict of an Incident.
+	VerdictId *int32 `json:"verdict_id,omitempty" parquet:"verdict_id,optional"`
 
 	// Vulnerabilities: Describes vulnerabilities reported in a Detection Finding.
 	Vulnerabilities []VulnerabilityDetails `json:"vulnerabilities,omitempty" parquet:"vulnerabilities,list,optional"`
@@ -146,42 +239,73 @@ func (v *DetectionFinding) ValidateObservables() error {
 }
 
 var DetectionFindingFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
 	{Name: "anomaly_analyses", Type: arrow.ListOf(AnomalyAnalysisStruct), Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "assignee", Type: UserStruct, Nullable: true},
+	{Name: "assignee_group", Type: GroupStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKATLASStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
 	{Name: "comment", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
 	{Name: "evidences", Type: arrow.ListOf(EvidenceArtifactsStruct), Nullable: true},
 	{Name: "finding_info", Type: FindingInformationStruct, Nullable: false},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "impact", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "impact_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "impact_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "is_suspected_breach", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
+	{Name: "malware_scan_info", Type: MalwareScanInfoStruct, Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
+	{Name: "priority", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "priority_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "raw_data_size", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "remediation", Type: RemediationStruct, Nullable: true},
 	{Name: "resources", Type: arrow.ListOf(ResourceDetailsStruct), Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
+	{Name: "src_url", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "start_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "status", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "status_code", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "status_detail", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "status_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "tickets", Type: arrow.ListOf(TicketStruct), Nullable: true},
 	{Name: "time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: false},
 	{Name: "timezone_offset", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "type_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "type_uid", Type: arrow.PrimitiveTypes.Int64, Nullable: false},
 	{Name: "unmapped", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "vendor_attributes", Type: VendorAttributesStruct, Nullable: true},
+	{Name: "verdict", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "verdict_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "vulnerabilities", Type: arrow.ListOf(VulnerabilityDetailsStruct), Nullable: true},
 }
 

--- a/ocsf/v1_5_0/device_config_state_change.go
+++ b/ocsf/v1_5_0/device_config_state_change.go
@@ -10,11 +10,29 @@ import (
 
 type DeviceConfigStateChange struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
+
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® and ATLAS™ Details: An array of MITRE ATT&CK® objects describing identified tactics, techniques & sub-techniques. The objects are compatible with MITRE ATLAS™ tactics, techniques & sub-techniques.
+	Attacks []MITREATTCKATLAS `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Discovery</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -28,14 +46,26 @@ type DeviceConfigStateChange struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
 
 	// Device: The device that is impacted by the state change.
 	Device Device `json:"device" parquet:"device"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -46,6 +76,18 @@ type DeviceConfigStateChange struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
+	// Malware Scan Info: Describes details about the scan job that identified malware on the target system.
+	MalwareScanInfo *MalwareScanInfo `json:"malware_scan_info,omitempty" parquet:"malware_scan_info,optional"`
+
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
 
@@ -55,8 +97,8 @@ type DeviceConfigStateChange struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Previous Security Level: The previous security level of the entity
 	PrevSecurityLevel *string `json:"prev_security_level,omitempty" parquet:"prev_security_level,optional"`
@@ -72,6 +114,18 @@ type DeviceConfigStateChange struct {
 
 	// Raw Data Size: The size of the raw data which was transformed into an OCSF event, in bytes.
 	RawDataSize *int64 `json:"raw_data_size,omitempty" parquet:"raw_data_size,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Security Level: The current security level of the entity
 	SecurityLevel *string `json:"security_level,omitempty" parquet:"security_level,optional"`
@@ -149,27 +203,45 @@ func (v *DeviceConfigStateChange) ValidateObservables() error {
 }
 
 var DeviceConfigStateChangeFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKATLASStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "device", Type: DeviceStruct, Nullable: false},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
+	{Name: "malware_scan_info", Type: MalwareScanInfoStruct, Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "prev_security_level", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "prev_security_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "prev_security_states", Type: arrow.ListOf(SecurityStateStruct), Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "raw_data_size", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "security_level", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "security_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "security_states", Type: arrow.ListOf(SecurityStateStruct), Nullable: true},

--- a/ocsf/v1_5_0/dhcp_activity.go
+++ b/ocsf/v1_5_0/dhcp_activity.go
@@ -10,14 +10,32 @@ import (
 
 type DHCPActivity struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
 
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
 	// Application Name: The name of the application associated with the event or object.
 	AppName *string `json:"app_name,omitempty" parquet:"app_name,optional"`
+
+	// MITRE ATT&CK® and ATLAS™ Details: An array of MITRE ATT&CK® objects describing identified tactics, techniques & sub-techniques. The objects are compatible with MITRE ATLAS™ tactics, techniques & sub-techniques.
+	Attacks []MITREATTCKATLAS `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Network Activity</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -31,14 +49,29 @@ type DHCPActivity struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Connection Info: The network connection information.
 	ConnectionInfo *NetworkConnectionInformation `json:"connection_info,omitempty" parquet:"connection_info,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
+
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Destination Endpoint: The responder (server) of the DHCP connection.
 	DstEndpoint *NetworkEndpoint `json:"dst_endpoint,omitempty" parquet:"dst_endpoint,optional"`
@@ -52,6 +85,12 @@ type DHCPActivity struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
 	// Renewal: Indicates whether this is a lease/session renewal event.
 	IsRenewal *bool `json:"is_renewal,omitempty" parquet:"is_renewal,optional"`
 
@@ -60,6 +99,12 @@ type DHCPActivity struct {
 
 	// Lease Duration: This represents the length of the DHCP lease in seconds. This is present in DHCP Ack events.
 	LeaseDur *int32 `json:"lease_dur,omitempty" parquet:"lease_dur,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
+	// Malware Scan Info: Describes details about the scan job that identified malware on the target system.
+	MalwareScanInfo *MalwareScanInfo `json:"malware_scan_info,omitempty" parquet:"malware_scan_info,optional"`
 
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
@@ -70,8 +115,26 @@ type DHCPActivity struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
+
+	// Proxy Connection Info: The connection information from the proxy server to the remote server.
+	ProxyConnectionInfo *NetworkConnectionInformation `json:"proxy_connection_info,omitempty" parquet:"proxy_connection_info,optional"`
+
+	// Proxy Endpoint: The proxy (server) in a network connection.
+	ProxyEndpoint *NetworkProxyEndpoint `json:"proxy_endpoint,omitempty" parquet:"proxy_endpoint,optional"`
+
+	// Proxy HTTP Request: The HTTP Request from the proxy server to the remote server.
+	ProxyHttpRequest *HTTPRequest `json:"proxy_http_request,omitempty" parquet:"proxy_http_request,optional"`
+
+	// Proxy HTTP Response: The HTTP Response from the remote server to the proxy server.
+	ProxyHttpResponse *HTTPResponse `json:"proxy_http_response,omitempty" parquet:"proxy_http_response,optional"`
+
+	// Proxy TLS: The TLS protocol negotiated between the proxy server and the remote server.
+	ProxyTls *TransportLayerSecurityTLS `json:"proxy_tls,omitempty" parquet:"proxy_tls,optional"`
+
+	// Proxy Traffic: The network traffic refers to the amount of data moving across a network, from proxy to remote server at a given point of time.
+	ProxyTraffic *NetworkTraffic `json:"proxy_traffic,omitempty" parquet:"proxy_traffic,optional"`
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
@@ -81,6 +144,18 @@ type DHCPActivity struct {
 
 	// Relay: The network relay that is associated with the event.
 	Relay *NetworkInterface `json:"relay,omitempty" parquet:"relay,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the <code>severity_id</code> value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -155,30 +230,55 @@ func (v *DHCPActivity) ValidateObservables() error {
 }
 
 var DHCPActivityFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
 	{Name: "app_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKATLASStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "connection_info", Type: NetworkConnectionInformationStruct, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "dst_endpoint", Type: NetworkEndpointStruct, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
 	{Name: "is_renewal", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
 	{Name: "ja4_fingerprint_list", Type: arrow.ListOf(JA4FingerprintStruct), Nullable: true},
 	{Name: "lease_dur", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
+	{Name: "malware_scan_info", Type: MalwareScanInfoStruct, Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
+	{Name: "proxy_connection_info", Type: NetworkConnectionInformationStruct, Nullable: true},
+	{Name: "proxy_endpoint", Type: NetworkProxyEndpointStruct, Nullable: true},
+	{Name: "proxy_http_request", Type: HTTPRequestStruct, Nullable: true},
+	{Name: "proxy_http_response", Type: HTTPResponseStruct, Nullable: true},
+	{Name: "proxy_tls", Type: TransportLayerSecurityTLSStruct, Nullable: true},
+	{Name: "proxy_traffic", Type: NetworkTrafficStruct, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "raw_data_size", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "relay", Type: NetworkInterfaceStruct, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "src_endpoint", Type: NetworkEndpointStruct, Nullable: true},

--- a/ocsf/v1_5_0/dns_activity.go
+++ b/ocsf/v1_5_0/dns_activity.go
@@ -10,17 +10,35 @@ import (
 
 type DNSActivity struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
 
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
 	// DNS Answer: The Domain Name System (DNS) answers.
 	Answers []DNSAnswer `json:"answers,omitempty" parquet:"answers,list,optional"`
 
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
 	// Application Name: The name of the application associated with the event or object.
 	AppName *string `json:"app_name,omitempty" parquet:"app_name,optional"`
+
+	// MITRE ATT&CK® and ATLAS™ Details: An array of MITRE ATT&CK® objects describing identified tactics, techniques & sub-techniques. The objects are compatible with MITRE ATLAS™ tactics, techniques & sub-techniques.
+	Attacks []MITREATTCKATLAS `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Network Activity</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -34,14 +52,29 @@ type DNSActivity struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Connection Info: The network connection information.
 	ConnectionInfo *NetworkConnectionInformation `json:"connection_info,omitempty" parquet:"connection_info,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
+
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Destination Endpoint: The responder (server) in a network connection.
 	DstEndpoint *NetworkEndpoint `json:"dst_endpoint,omitempty" parquet:"dst_endpoint,optional"`
@@ -55,8 +88,20 @@ type DNSActivity struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
 	// JA4+ Fingerprints: A list of the JA4+ network fingerprints.
 	Ja4FingerprintList []JA4Fingerprint `json:"ja4_fingerprint_list,omitempty" parquet:"ja4_fingerprint_list,list,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
+	// Malware Scan Info: Describes details about the scan job that identified malware on the target system.
+	MalwareScanInfo *MalwareScanInfo `json:"malware_scan_info,omitempty" parquet:"malware_scan_info,optional"`
 
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
@@ -67,8 +112,26 @@ type DNSActivity struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
+
+	// Proxy Connection Info: The connection information from the proxy server to the remote server.
+	ProxyConnectionInfo *NetworkConnectionInformation `json:"proxy_connection_info,omitempty" parquet:"proxy_connection_info,optional"`
+
+	// Proxy Endpoint: The proxy (server) in a network connection.
+	ProxyEndpoint *NetworkProxyEndpoint `json:"proxy_endpoint,omitempty" parquet:"proxy_endpoint,optional"`
+
+	// Proxy HTTP Request: The HTTP Request from the proxy server to the remote server.
+	ProxyHttpRequest *HTTPRequest `json:"proxy_http_request,omitempty" parquet:"proxy_http_request,optional"`
+
+	// Proxy HTTP Response: The HTTP Response from the remote server to the proxy server.
+	ProxyHttpResponse *HTTPResponse `json:"proxy_http_response,omitempty" parquet:"proxy_http_response,optional"`
+
+	// Proxy TLS: The TLS protocol negotiated between the proxy server and the remote server.
+	ProxyTls *TransportLayerSecurityTLS `json:"proxy_tls,omitempty" parquet:"proxy_tls,optional"`
+
+	// Proxy Traffic: The network traffic refers to the amount of data moving across a network, from proxy to remote server at a given point of time.
+	ProxyTraffic *NetworkTraffic `json:"proxy_traffic,omitempty" parquet:"proxy_traffic,optional"`
 
 	// DNS Query: The Domain Name System (DNS) query.
 	Query *DNSQuery `json:"query,omitempty" parquet:"query,optional"`
@@ -90,6 +153,18 @@ type DNSActivity struct {
 
 	// Response Time: The Domain Name System (DNS) response time.
 	ResponseTime int64 `json:"response_time,omitempty" parquet:"response_time,timestamp_millis,timestamp(millisecond),optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the <code>severity_id</code> value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -161,26 +236,47 @@ func (v *DNSActivity) ValidateObservables() error {
 }
 
 var DNSActivityFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
 	{Name: "answers", Type: arrow.ListOf(DNSAnswerStruct), Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
 	{Name: "app_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKATLASStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "connection_info", Type: NetworkConnectionInformationStruct, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "dst_endpoint", Type: NetworkEndpointStruct, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
 	{Name: "ja4_fingerprint_list", Type: arrow.ListOf(JA4FingerprintStruct), Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
+	{Name: "malware_scan_info", Type: MalwareScanInfoStruct, Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
+	{Name: "proxy_connection_info", Type: NetworkConnectionInformationStruct, Nullable: true},
+	{Name: "proxy_endpoint", Type: NetworkProxyEndpointStruct, Nullable: true},
+	{Name: "proxy_http_request", Type: HTTPRequestStruct, Nullable: true},
+	{Name: "proxy_http_response", Type: HTTPResponseStruct, Nullable: true},
+	{Name: "proxy_tls", Type: TransportLayerSecurityTLSStruct, Nullable: true},
+	{Name: "proxy_traffic", Type: NetworkTrafficStruct, Nullable: true},
 	{Name: "query", Type: DNSQueryStruct, Nullable: true},
 	{Name: "query_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
@@ -188,6 +284,10 @@ var DNSActivityFields = []arrow.Field{
 	{Name: "rcode", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "rcode_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "response_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "src_endpoint", Type: NetworkEndpointStruct, Nullable: true},

--- a/ocsf/v1_5_0/drone_flights_activity.go
+++ b/ocsf/v1_5_0/drone_flights_activity.go
@@ -10,17 +10,35 @@ import (
 
 type DroneFlightsActivity struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
 
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® and ATLAS™ Details: An array of MITRE ATT&CK® objects describing identified tactics, techniques & sub-techniques. The objects are compatible with MITRE ATLAS™ tactics, techniques & sub-techniques.
+	Attacks []MITREATTCKATLAS `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
 	// Authentication Type: The authentication type as defined by the caption of <code>auth_protocol_id</code>. In the case of 'Other', it is defined by the event source.
 	AuthProtocol *string `json:"auth_protocol,omitempty" parquet:"auth_protocol,optional"`
 
 	// Authentication Type ID: The normalized identifier of the authentication type used to authorize a flight plan or mission.
 	AuthProtocolId *int32 `json:"auth_protocol_id,omitempty" parquet:"auth_protocol_id,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Unmanned Systems</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -37,17 +55,32 @@ type DroneFlightsActivity struct {
 	// Classification Type: UA Classification - Allows a region to classify UAS in a regional specific manner. The format may differ from region to region.
 	Classification *string `json:"classification,omitempty" parquet:"classification,optional"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
-
 	// Operation Description: This optional, free-text field enables the operator to describe the purpose of a flight, if so desired.
 	Comment *string `json:"comment,omitempty" parquet:"comment,optional"`
+
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Connection Info: The network connection information.
 	ConnectionInfo *NetworkConnectionInformation `json:"connection_info,omitempty" parquet:"connection_info,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
+
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Destination Endpoint: The destination network endpoint of the Unmanned Aerial System (UAS), Counter Unmanned Aerial System (CUAS) platform, or other unmanned systems monitoring and/or sensing infrastructure.
 	DstEndpoint NetworkEndpoint `json:"dst_endpoint" parquet:"dst_endpoint"`
@@ -61,6 +94,18 @@ type DroneFlightsActivity struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
+	// Malware Scan Info: Describes details about the scan job that identified malware on the target system.
+	MalwareScanInfo *MalwareScanInfo `json:"malware_scan_info,omitempty" parquet:"malware_scan_info,optional"`
+
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
 
@@ -70,8 +115,8 @@ type DroneFlightsActivity struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Remote ID Protocol: The networking protocol associated with the Remote ID device or beacon. E.g. <code>BLE</code>, <code>LTE</code>, <code>802.11</code>.
 	ProtocolName *string `json:"protocol_name,omitempty" parquet:"protocol_name,optional"`
@@ -84,6 +129,18 @@ type DroneFlightsActivity struct {
 
 	// Raw Data Size: The size of the raw data which was transformed into an OCSF event, in bytes.
 	RawDataSize *int64 `json:"raw_data_size,omitempty" parquet:"raw_data_size,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the <code>severity_id</code> value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -164,31 +221,50 @@ func (v *DroneFlightsActivity) ValidateObservables() error {
 }
 
 var DroneFlightsActivityFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKATLASStruct), Nullable: true},
 	{Name: "auth_protocol", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "auth_protocol_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "classification", Type: arrow.BinaryTypes.String, Nullable: true},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
 	{Name: "comment", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "connection_info", Type: NetworkConnectionInformationStruct, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "dst_endpoint", Type: NetworkEndpointStruct, Nullable: false},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
+	{Name: "malware_scan_info", Type: MalwareScanInfoStruct, Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "protocol_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "proxy_endpoint", Type: NetworkProxyEndpointStruct, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "raw_data_size", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "src_endpoint", Type: NetworkEndpointStruct, Nullable: true},

--- a/ocsf/v1_5_0/email_activity.go
+++ b/ocsf/v1_5_0/email_activity.go
@@ -10,14 +10,32 @@ import (
 
 type EmailActivity struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
 
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® and ATLAS™ Details: An array of MITRE ATT&CK® objects describing identified tactics, techniques & sub-techniques. The objects are compatible with MITRE ATLAS™ tactics, techniques & sub-techniques.
+	Attacks []MITREATTCKATLAS `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
 	// Attempt: The attempt number for attempting to deliver the email.
 	Attempt *int32 `json:"attempt,omitempty" parquet:"attempt,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Protocol Banner: The initial connection response that a messaging server receives after it connects to an email server.
 	Banner *string `json:"banner,omitempty" parquet:"banner,optional"`
@@ -34,20 +52,35 @@ type EmailActivity struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
-
 	// Command: The command issued by the initiator (client), such as SMTP HELO or EHLO.
 	Command *string `json:"command,omitempty" parquet:"command,optional"`
 
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
+
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
+
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
 
 	// Direction: The direction of the email, as defined by the <code>direction_id</code> value.
 	Direction *string `json:"direction,omitempty" parquet:"direction,optional"`
 
 	// Direction ID: <p>The direction of the email relative to the scanning host or organization.</p>Email scanned at an internet gateway might be characterized as inbound to the organization from the Internet, outbound from the organization to the Internet, or internal within the organization. Email scanned at a workstation might be characterized as inbound to, or outbound from the workstation.
 	DirectionId int32 `json:"direction_id" parquet:"direction_id"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Destination Endpoint: The responder (server) receiving the email.
 	DstEndpoint *NetworkEndpoint `json:"dst_endpoint,omitempty" parquet:"dst_endpoint,optional"`
@@ -67,6 +100,18 @@ type EmailActivity struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
+	// Malware Scan Info: Describes details about the scan job that identified malware on the target system.
+	MalwareScanInfo *MalwareScanInfo `json:"malware_scan_info,omitempty" parquet:"malware_scan_info,optional"`
+
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
 
@@ -79,8 +124,8 @@ type EmailActivity struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Protocol Name: The Protocol Name specifies the email communication protocol, such as SMTP, IMAP, or POP3.
 	ProtocolName *string `json:"protocol_name,omitempty" parquet:"protocol_name,optional"`
@@ -90,6 +135,18 @@ type EmailActivity struct {
 
 	// Raw Data Size: The size of the raw data which was transformed into an OCSF event, in bytes.
 	RawDataSize *int64 `json:"raw_data_size,omitempty" parquet:"raw_data_size,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the <code>severity_id</code> value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -155,33 +212,52 @@ func (v *EmailActivity) ValidateObservables() error {
 }
 
 var EmailActivityFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKATLASStruct), Nullable: true},
 	{Name: "attempt", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "banner", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
 	{Name: "command", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
 	{Name: "direction", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "direction_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "dst_endpoint", Type: NetworkEndpointStruct, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "email", Type: EmailStruct, Nullable: false},
 	{Name: "email_auth", Type: EmailAuthenticationStruct, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
+	{Name: "malware_scan_info", Type: MalwareScanInfoStruct, Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "message_trace_uid", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "protocol_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "raw_data_size", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "src_endpoint", Type: NetworkEndpointStruct, Nullable: true},

--- a/ocsf/v1_5_0/email_file_activity.go
+++ b/ocsf/v1_5_0/email_file_activity.go
@@ -10,11 +10,29 @@ import (
 
 type EmailFileActivity struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
+
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® and ATLAS™ Details: An array of MITRE ATT&CK® objects describing identified tactics, techniques & sub-techniques. The objects are compatible with MITRE ATLAS™ tactics, techniques & sub-techniques.
+	Attacks []MITREATTCKATLAS `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Network Activity</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -28,11 +46,26 @@ type EmailFileActivity struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
+
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -46,6 +79,18 @@ type EmailFileActivity struct {
 	// File: The email file attachment.
 	File File `json:"file" parquet:"file"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
+	// Malware Scan Info: Describes details about the scan job that identified malware on the target system.
+	MalwareScanInfo *MalwareScanInfo `json:"malware_scan_info,omitempty" parquet:"malware_scan_info,optional"`
+
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
 
@@ -55,14 +100,26 @@ type EmailFileActivity struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
 
 	// Raw Data Size: The size of the raw data which was transformed into an OCSF event, in bytes.
 	RawDataSize *int64 `json:"raw_data_size,omitempty" parquet:"raw_data_size,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the <code>severity_id</code> value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -125,24 +182,43 @@ func (v *EmailFileActivity) ValidateObservables() error {
 }
 
 var EmailFileActivityFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKATLASStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
 	{Name: "file", Type: FileStruct, Nullable: false},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
+	{Name: "malware_scan_info", Type: MalwareScanInfoStruct, Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "raw_data_size", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "start_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},

--- a/ocsf/v1_5_0/email_url_activity.go
+++ b/ocsf/v1_5_0/email_url_activity.go
@@ -10,11 +10,29 @@ import (
 
 type EmailURLActivity struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
+
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® and ATLAS™ Details: An array of MITRE ATT&CK® objects describing identified tactics, techniques & sub-techniques. The objects are compatible with MITRE ATLAS™ tactics, techniques & sub-techniques.
+	Attacks []MITREATTCKATLAS `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Network Activity</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -28,11 +46,26 @@ type EmailURLActivity struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
+
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -43,6 +76,18 @@ type EmailURLActivity struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
+	// Malware Scan Info: Describes details about the scan job that identified malware on the target system.
+	MalwareScanInfo *MalwareScanInfo `json:"malware_scan_info,omitempty" parquet:"malware_scan_info,optional"`
+
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
 
@@ -52,14 +97,26 @@ type EmailURLActivity struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
 
 	// Raw Data Size: The size of the raw data which was transformed into an OCSF event, in bytes.
 	RawDataSize *int64 `json:"raw_data_size,omitempty" parquet:"raw_data_size,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the <code>severity_id</code> value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -125,23 +182,42 @@ func (v *EmailURLActivity) ValidateObservables() error {
 }
 
 var EmailURLActivityFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKATLASStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
+	{Name: "malware_scan_info", Type: MalwareScanInfoStruct, Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "raw_data_size", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "start_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},

--- a/ocsf/v1_5_0/entity_management.go
+++ b/ocsf/v1_5_0/entity_management.go
@@ -16,11 +16,29 @@ type EntityManagement struct {
 	// Access Mask: The access mask in a platform-native format.
 	AccessMask *int32 `json:"access_mask,omitempty" parquet:"access_mask,optional"`
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
+
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® and ATLAS™ Details: An array of MITRE ATT&CK® objects describing identified tactics, techniques & sub-techniques. The objects are compatible with MITRE ATLAS™ tactics, techniques & sub-techniques.
+	Attacks []MITREATTCKATLAS `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Identity & Access Management</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -34,14 +52,29 @@ type EntityManagement struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
-
 	// Comment: The user provided comment about why the entity was changed.
 	Comment *string `json:"comment,omitempty" parquet:"comment,optional"`
 
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
+
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
+
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -58,11 +91,23 @@ type EntityManagement struct {
 	// Entity Result: The updated managed entity.
 	EntityResult *ManagedEntity `json:"entity_result,omitempty" parquet:"entity_result,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
 	// HTTP Request: Details about the underlying HTTP request.
 	HttpRequest *HTTPRequest `json:"http_request,omitempty" parquet:"http_request,optional"`
 
 	// HTTP Response: Details about the underlying HTTP response.
 	HttpResponse *HTTPResponse `json:"http_response,omitempty" parquet:"http_response,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
+	// Malware Scan Info: Describes details about the scan job that identified malware on the target system.
+	MalwareScanInfo *MalwareScanInfo `json:"malware_scan_info,omitempty" parquet:"malware_scan_info,optional"`
 
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
@@ -73,14 +118,26 @@ type EntityManagement struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
 
 	// Raw Data Size: The size of the raw data which was transformed into an OCSF event, in bytes.
 	RawDataSize *int64 `json:"raw_data_size,omitempty" parquet:"raw_data_size,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the <code>severity_id</code> value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -148,28 +205,47 @@ func (v *EntityManagement) ValidateObservables() error {
 var EntityManagementFields = []arrow.Field{
 	{Name: "access_list", Type: arrow.ListOf(arrow.BinaryTypes.String), Nullable: true},
 	{Name: "access_mask", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKATLASStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
 	{Name: "comment", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
 	{Name: "entity", Type: ManagedEntityStruct, Nullable: false},
 	{Name: "entity_result", Type: ManagedEntityStruct, Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
 	{Name: "http_request", Type: HTTPRequestStruct, Nullable: true},
 	{Name: "http_response", Type: HTTPResponseStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
+	{Name: "malware_scan_info", Type: MalwareScanInfoStruct, Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "raw_data_size", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "src_endpoint", Type: NetworkEndpointStruct, Nullable: true},

--- a/ocsf/v1_5_0/event_log_actvity.go
+++ b/ocsf/v1_5_0/event_log_actvity.go
@@ -10,11 +10,29 @@ import (
 
 type EventLogActivity struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
+
+	// Actor: The actor that performed the activity.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® and ATLAS™ Details: An array of MITRE ATT&CK® objects describing identified tactics, techniques & sub-techniques. The objects are compatible with MITRE ATLAS™ tactics, techniques & sub-techniques.
+	Attacks []MITREATTCKATLAS `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>System Activity</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -28,11 +46,26 @@ type EventLogActivity struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
+
+	// Device: The device that reported the event.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Destination Endpoint: The <p style='display:inline;color:red'>targeted</p> endpoint for the event log activity.
 	DstEndpoint *NetworkEndpoint `json:"dst_endpoint,omitempty" parquet:"dst_endpoint,optional"`
@@ -49,6 +82,12 @@ type EventLogActivity struct {
 	// File: The file <p style='display:inline;color:red'>targeted by</p> the activity. Example: <code>/var/log/audit.log</code>
 	File *File `json:"file,omitempty" parquet:"file,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
 	// Log Name: The name of the event log <p style='display:inline;color:red'>targeted by</p> the activity. Example: Windows <code>Security</code>.
 	LogName *string `json:"log_name,omitempty" parquet:"log_name,optional"`
 
@@ -61,6 +100,12 @@ type EventLogActivity struct {
 	// Log Type ID: The normalized log type identifier.
 	LogTypeId *int32 `json:"log_type_id,omitempty" parquet:"log_type_id,optional"`
 
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
+	// Malware Scan Info: Describes details about the scan job that identified malware on the target system.
+	MalwareScanInfo *MalwareScanInfo `json:"malware_scan_info,omitempty" parquet:"malware_scan_info,optional"`
+
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
 
@@ -70,14 +115,26 @@ type EventLogActivity struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
 
 	// Raw Data Size: The size of the raw data which was transformed into an OCSF event, in bytes.
 	RawDataSize *int64 `json:"raw_data_size,omitempty" parquet:"raw_data_size,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the <code>severity_id</code> value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -143,29 +200,48 @@ func (v *EventLogActivity) ValidateObservables() error {
 }
 
 var EventLogActivityFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKATLASStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "dst_endpoint", Type: NetworkEndpointStruct, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
 	{Name: "file", Type: FileStruct, Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
 	{Name: "log_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "log_provider", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "log_type", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "log_type_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
+	{Name: "malware_scan_info", Type: MalwareScanInfoStruct, Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "raw_data_size", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "src_endpoint", Type: NetworkEndpointStruct, Nullable: true},

--- a/ocsf/v1_5_0/evidence_info.go
+++ b/ocsf/v1_5_0/evidence_info.go
@@ -10,11 +10,29 @@ import (
 
 type LiveEvidenceInfo struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
+
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® and ATLAS™ Details: An array of MITRE ATT&CK® objects describing identified tactics, techniques & sub-techniques. The objects are compatible with MITRE ATLAS™ tactics, techniques & sub-techniques.
+	Attacks []MITREATTCKATLAS `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Discovery</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -28,14 +46,26 @@ type LiveEvidenceInfo struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
 
 	// Device: An addressable device, computer system or host from which evidence was collected.
 	Device Device `json:"device" parquet:"device"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -46,6 +76,18 @@ type LiveEvidenceInfo struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
+	// Malware Scan Info: Describes details about the scan job that identified malware on the target system.
+	MalwareScanInfo *MalwareScanInfo `json:"malware_scan_info,omitempty" parquet:"malware_scan_info,optional"`
+
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
 
@@ -55,8 +97,8 @@ type LiveEvidenceInfo struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Query Evidence: The specific resulting evidence information that was queried or discovered based on the query type. Contains various child objects corresponding to the query_type_id values.
 	QueryEvidence QueryEvidence `json:"query_evidence" parquet:"query_evidence"`
@@ -75,6 +117,18 @@ type LiveEvidenceInfo struct {
 
 	// Raw Data Size: The size of the raw data which was transformed into an OCSF event, in bytes.
 	RawDataSize *int64 `json:"raw_data_size,omitempty" parquet:"raw_data_size,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the <code>severity_id</code> value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -137,28 +191,46 @@ func (v *LiveEvidenceInfo) ValidateObservables() error {
 }
 
 var LiveEvidenceInfoFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKATLASStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "device", Type: DeviceStruct, Nullable: false},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
+	{Name: "malware_scan_info", Type: MalwareScanInfoStruct, Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "query_evidence", Type: QueryEvidenceStruct, Nullable: false},
 	{Name: "query_info", Type: QueryInformationStruct, Nullable: true},
 	{Name: "query_result", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "query_result_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "raw_data_size", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "start_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},

--- a/ocsf/v1_5_0/file_activity.go
+++ b/ocsf/v1_5_0/file_activity.go
@@ -13,6 +13,12 @@ type FileSystemActivity struct {
 	// Access Mask: The access mask in a platform-native format.
 	AccessMask *int32 `json:"access_mask,omitempty" parquet:"access_mask,optional"`
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
@@ -21,6 +27,15 @@ type FileSystemActivity struct {
 
 	// Actor: The actor that performed the activity on the <code>file</code> object
 	Actor Actor `json:"actor" parquet:"actor"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® and ATLAS™ Details: An array of MITRE ATT&CK® objects describing identified tactics, techniques & sub-techniques. The objects are compatible with MITRE ATLAS™ tactics, techniques & sub-techniques.
+	Attacks []MITREATTCKATLAS `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>System Activity</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -34,11 +49,17 @@ type FileSystemActivity struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
-
 	// Component: <p>The name or relative pathname of a sub-component of the data object, if applicable. </p>For example: <code>attachment.doc</code>, <code>attachment.zip/bad.doc</code>, or <code>part.mime/part.cab/part.uue/part.doc</code>.
 	Component *string `json:"component,omitempty" parquet:"component,optional"`
+
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Connection Identifier: The network connection identifier.
 	ConnectionUid *string `json:"connection_uid,omitempty" parquet:"connection_uid,optional"`
@@ -51,6 +72,12 @@ type FileSystemActivity struct {
 
 	// Device: An addressable device, computer system or host.
 	Device Device `json:"device" parquet:"device"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -70,6 +97,18 @@ type FileSystemActivity struct {
 	// File Result: The resulting file object when the activity was allowed and successful.
 	FileResult *File `json:"file_result,omitempty" parquet:"file_result,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
+	// Malware Scan Info: Describes details about the scan job that identified malware on the target system.
+	MalwareScanInfo *MalwareScanInfo `json:"malware_scan_info,omitempty" parquet:"malware_scan_info,optional"`
+
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
 
@@ -79,14 +118,26 @@ type FileSystemActivity struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
 
 	// Raw Data Size: The size of the raw data which was transformed into an OCSF event, in bytes.
 	RawDataSize *int64 `json:"raw_data_size,omitempty" parquet:"raw_data_size,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the <code>severity_id</code> value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -150,31 +201,48 @@ func (v *FileSystemActivity) ValidateObservables() error {
 
 var FileSystemActivityFields = []arrow.Field{
 	{Name: "access_mask", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "actor", Type: ActorStruct, Nullable: false},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKATLASStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
 	{Name: "component", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "connection_uid", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "create_mask", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "device", Type: DeviceStruct, Nullable: false},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
 	{Name: "file", Type: FileStruct, Nullable: false},
 	{Name: "file_diff", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "file_result", Type: FileStruct, Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
+	{Name: "malware_scan_info", Type: MalwareScanInfoStruct, Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "raw_data_size", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "start_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},

--- a/ocsf/v1_5_0/file_hosting.go
+++ b/ocsf/v1_5_0/file_hosting.go
@@ -19,6 +19,12 @@ type FileHostingActivity struct {
 	// Access Check Result: The list of access check results.
 	AccessResult *string `json:"access_result,omitempty" parquet:"access_result,optional"`
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
@@ -27,6 +33,15 @@ type FileHostingActivity struct {
 
 	// Actor: The actor that performed the activity on the target file.
 	Actor Actor `json:"actor" parquet:"actor"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® and ATLAS™ Details: An array of MITRE ATT&CK® objects describing identified tactics, techniques & sub-techniques. The objects are compatible with MITRE ATLAS™ tactics, techniques & sub-techniques.
+	Attacks []MITREATTCKATLAS `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Application Activity</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -40,14 +55,29 @@ type FileHostingActivity struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Connection Info: The network connection information.
 	ConnectionInfo *NetworkConnectionInformation `json:"connection_info,omitempty" parquet:"connection_info,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
+
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Destination Endpoint: The endpoint that received the activity on the target file.
 	DstEndpoint *NetworkEndpoint `json:"dst_endpoint,omitempty" parquet:"dst_endpoint,optional"`
@@ -70,6 +100,18 @@ type FileHostingActivity struct {
 	// File Result: The resulting file object when the activity was allowed and successful.
 	FileResult *File `json:"file_result,omitempty" parquet:"file_result,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
+	// Malware Scan Info: Describes details about the scan job that identified malware on the target system.
+	MalwareScanInfo *MalwareScanInfo `json:"malware_scan_info,omitempty" parquet:"malware_scan_info,optional"`
+
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
 
@@ -79,14 +121,26 @@ type FileHostingActivity struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
 
 	// Raw Data Size: The size of the raw data which was transformed into an OCSF event, in bytes.
 	RawDataSize *int64 `json:"raw_data_size,omitempty" parquet:"raw_data_size,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the <code>severity_id</code> value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -164,16 +218,26 @@ var FileHostingActivityFields = []arrow.Field{
 	{Name: "access_list", Type: arrow.ListOf(arrow.BinaryTypes.String), Nullable: true},
 	{Name: "access_mask", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "access_result", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "actor", Type: ActorStruct, Nullable: false},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKATLASStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "connection_info", Type: NetworkConnectionInformationStruct, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "dst_endpoint", Type: NetworkEndpointStruct, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
@@ -181,12 +245,20 @@ var FileHostingActivityFields = []arrow.Field{
 	{Name: "expiration_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "file", Type: FileStruct, Nullable: false},
 	{Name: "file_result", Type: FileStruct, Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
+	{Name: "malware_scan_info", Type: MalwareScanInfoStruct, Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "raw_data_size", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "share", Type: arrow.BinaryTypes.String, Nullable: true},

--- a/ocsf/v1_5_0/file_query.go
+++ b/ocsf/v1_5_0/file_query.go
@@ -10,11 +10,29 @@ import (
 
 type FileQuery struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
+
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® and ATLAS™ Details: An array of MITRE ATT&CK® objects describing identified tactics, techniques & sub-techniques. The objects are compatible with MITRE ATLAS™ tactics, techniques & sub-techniques.
+	Attacks []MITREATTCKATLAS `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Discovery</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -28,11 +46,26 @@ type FileQuery struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
+
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -46,6 +79,18 @@ type FileQuery struct {
 	// File: The file that is the target of the query.
 	File File `json:"file" parquet:"file"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
+	// Malware Scan Info: Describes details about the scan job that identified malware on the target system.
+	MalwareScanInfo *MalwareScanInfo `json:"malware_scan_info,omitempty" parquet:"malware_scan_info,optional"`
+
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
 
@@ -55,8 +100,8 @@ type FileQuery struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Query Info: The search details associated with the query request.
 	QueryInfo *QueryInformation `json:"query_info,omitempty" parquet:"query_info,optional"`
@@ -72,6 +117,18 @@ type FileQuery struct {
 
 	// Raw Data Size: The size of the raw data which was transformed into an OCSF event, in bytes.
 	RawDataSize *int64 `json:"raw_data_size,omitempty" parquet:"raw_data_size,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the <code>severity_id</code> value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -134,27 +191,46 @@ func (v *FileQuery) ValidateObservables() error {
 }
 
 var FileQueryFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKATLASStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
 	{Name: "file", Type: FileStruct, Nullable: false},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
+	{Name: "malware_scan_info", Type: MalwareScanInfoStruct, Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "query_info", Type: QueryInformationStruct, Nullable: true},
 	{Name: "query_result", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "query_result_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "raw_data_size", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "start_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},

--- a/ocsf/v1_5_0/file_remediation_activity.go
+++ b/ocsf/v1_5_0/file_remediation_activity.go
@@ -10,11 +10,29 @@ import (
 
 type FileRemediationActivity struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: Matches the MITRE D3FEND™ Tactic. Note: the Model and Detect Tactics are not supported as remediations by the OCSF Remediation event class.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
+
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® and ATLAS™ Details: An array of MITRE ATT&CK® objects describing identified tactics, techniques & sub-techniques. The objects are compatible with MITRE ATLAS™ tactics, techniques & sub-techniques.
+	Attacks []MITREATTCKATLAS `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Remediation</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -28,17 +46,32 @@ type FileRemediationActivity struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
-
 	// Command UID: The unique identifier of the remediation command that pertains to this event.
 	CommandUid string `json:"command_uid" parquet:"command_uid"`
+
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
 
 	// Countermeasures: The MITRE D3FEND™ Matrix Countermeasures associated with a remediation.
 	Countermeasures []MITRED3FEND `json:"countermeasures,omitempty" parquet:"countermeasures,list,optional"`
+
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -52,6 +85,18 @@ type FileRemediationActivity struct {
 	// File: The file that pertains to the remediation event.
 	File File `json:"file" parquet:"file"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
+	// Malware Scan Info: Describes details about the scan job that identified malware on the target system.
+	MalwareScanInfo *MalwareScanInfo `json:"malware_scan_info,omitempty" parquet:"malware_scan_info,optional"`
+
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
 
@@ -61,8 +106,8 @@ type FileRemediationActivity struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
@@ -72,6 +117,18 @@ type FileRemediationActivity struct {
 
 	// Remediation Guidance: Describes the recommended remediation steps to address identified issue(s).
 	Remediation *Remediation `json:"remediation,omitempty" parquet:"remediation,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Scan: The remediation scan that pertains to this event.
 	Scan *Scan `json:"scan,omitempty" parquet:"scan,optional"`
@@ -137,27 +194,46 @@ func (v *FileRemediationActivity) ValidateObservables() error {
 }
 
 var FileRemediationActivityFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKATLASStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
 	{Name: "command_uid", Type: arrow.BinaryTypes.String, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "countermeasures", Type: arrow.ListOf(MITRED3FENDStruct), Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
 	{Name: "file", Type: FileStruct, Nullable: false},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
+	{Name: "malware_scan_info", Type: MalwareScanInfoStruct, Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "raw_data_size", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "remediation", Type: RemediationStruct, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "scan", Type: ScanStruct, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},

--- a/ocsf/v1_5_0/folder_query.go
+++ b/ocsf/v1_5_0/folder_query.go
@@ -10,11 +10,29 @@ import (
 
 type FolderQuery struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
+
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® and ATLAS™ Details: An array of MITRE ATT&CK® objects describing identified tactics, techniques & sub-techniques. The objects are compatible with MITRE ATLAS™ tactics, techniques & sub-techniques.
+	Attacks []MITREATTCKATLAS `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Discovery</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -28,11 +46,26 @@ type FolderQuery struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
+
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -43,8 +76,20 @@ type FolderQuery struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
 	// Folder: The folder that is the target of the query.
 	Folder File `json:"folder" parquet:"folder"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
+	// Malware Scan Info: Describes details about the scan job that identified malware on the target system.
+	MalwareScanInfo *MalwareScanInfo `json:"malware_scan_info,omitempty" parquet:"malware_scan_info,optional"`
 
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
@@ -55,8 +100,8 @@ type FolderQuery struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Query Info: The search details associated with the query request.
 	QueryInfo *QueryInformation `json:"query_info,omitempty" parquet:"query_info,optional"`
@@ -72,6 +117,18 @@ type FolderQuery struct {
 
 	// Raw Data Size: The size of the raw data which was transformed into an OCSF event, in bytes.
 	RawDataSize *int64 `json:"raw_data_size,omitempty" parquet:"raw_data_size,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the <code>severity_id</code> value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -134,27 +191,46 @@ func (v *FolderQuery) ValidateObservables() error {
 }
 
 var FolderQueryFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKATLASStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
 	{Name: "folder", Type: FileStruct, Nullable: false},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
+	{Name: "malware_scan_info", Type: MalwareScanInfoStruct, Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "query_info", Type: QueryInformationStruct, Nullable: true},
 	{Name: "query_result", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "query_result_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "raw_data_size", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "start_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},

--- a/ocsf/v1_5_0/ftp_activity.go
+++ b/ocsf/v1_5_0/ftp_activity.go
@@ -10,14 +10,32 @@ import (
 
 type FTPActivity struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
 
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
 	// Application Name: The name of the application associated with the event or object.
 	AppName *string `json:"app_name,omitempty" parquet:"app_name,optional"`
+
+	// MITRE ATT&CK® and ATLAS™ Details: An array of MITRE ATT&CK® objects describing identified tactics, techniques & sub-techniques. The objects are compatible with MITRE ATLAS™ tactics, techniques & sub-techniques.
+	Attacks []MITREATTCKATLAS `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Network Activity</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -31,9 +49,6 @@ type FTPActivity struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
-
 	// Response Codes: The list of return codes to the FTP command.
 	Codes []int32 `json:"codes,omitempty" parquet:"codes,list,optional"`
 
@@ -43,11 +58,29 @@ type FTPActivity struct {
 	// Command Responses: The list of responses to the FTP command.
 	CommandResponses []string `json:"command_responses,omitempty" parquet:"command_responses,list,optional"`
 
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
+
 	// Connection Info: The network connection information.
 	ConnectionInfo *NetworkConnectionInformation `json:"connection_info,omitempty" parquet:"connection_info,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
+
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Destination Endpoint: The responder (server) in a network connection.
 	DstEndpoint *NetworkEndpoint `json:"dst_endpoint,omitempty" parquet:"dst_endpoint,optional"`
@@ -64,8 +97,20 @@ type FTPActivity struct {
 	// File: The file that is the target of the FTP activity.
 	File *File `json:"file,omitempty" parquet:"file,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
 	// JA4+ Fingerprints: A list of the JA4+ network fingerprints.
 	Ja4FingerprintList []JA4Fingerprint `json:"ja4_fingerprint_list,omitempty" parquet:"ja4_fingerprint_list,list,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
+	// Malware Scan Info: Describes details about the scan job that identified malware on the target system.
+	MalwareScanInfo *MalwareScanInfo `json:"malware_scan_info,omitempty" parquet:"malware_scan_info,optional"`
 
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
@@ -79,17 +124,47 @@ type FTPActivity struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Port: The dynamic port established for impending data transfers.
 	Port *int32 `json:"port,omitempty" parquet:"port,optional"`
+
+	// Proxy Connection Info: The connection information from the proxy server to the remote server.
+	ProxyConnectionInfo *NetworkConnectionInformation `json:"proxy_connection_info,omitempty" parquet:"proxy_connection_info,optional"`
+
+	// Proxy Endpoint: The proxy (server) in a network connection.
+	ProxyEndpoint *NetworkProxyEndpoint `json:"proxy_endpoint,omitempty" parquet:"proxy_endpoint,optional"`
+
+	// Proxy HTTP Request: The HTTP Request from the proxy server to the remote server.
+	ProxyHttpRequest *HTTPRequest `json:"proxy_http_request,omitempty" parquet:"proxy_http_request,optional"`
+
+	// Proxy HTTP Response: The HTTP Response from the remote server to the proxy server.
+	ProxyHttpResponse *HTTPResponse `json:"proxy_http_response,omitempty" parquet:"proxy_http_response,optional"`
+
+	// Proxy TLS: The TLS protocol negotiated between the proxy server and the remote server.
+	ProxyTls *TransportLayerSecurityTLS `json:"proxy_tls,omitempty" parquet:"proxy_tls,optional"`
+
+	// Proxy Traffic: The network traffic refers to the amount of data moving across a network, from proxy to remote server at a given point of time.
+	ProxyTraffic *NetworkTraffic `json:"proxy_traffic,omitempty" parquet:"proxy_traffic,optional"`
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
 
 	// Raw Data Size: The size of the raw data which was transformed into an OCSF event, in bytes.
 	RawDataSize *int64 `json:"raw_data_size,omitempty" parquet:"raw_data_size,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the <code>severity_id</code> value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -164,33 +239,58 @@ func (v *FTPActivity) ValidateObservables() error {
 }
 
 var FTPActivityFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
 	{Name: "app_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKATLASStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
 	{Name: "codes", Type: arrow.ListOf(arrow.PrimitiveTypes.Int32), Nullable: true},
 	{Name: "command", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "command_responses", Type: arrow.ListOf(arrow.BinaryTypes.String), Nullable: true},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "connection_info", Type: NetworkConnectionInformationStruct, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "dst_endpoint", Type: NetworkEndpointStruct, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
 	{Name: "file", Type: FileStruct, Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
 	{Name: "ja4_fingerprint_list", Type: arrow.ListOf(JA4FingerprintStruct), Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
+	{Name: "malware_scan_info", Type: MalwareScanInfoStruct, Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "port", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "proxy_connection_info", Type: NetworkConnectionInformationStruct, Nullable: true},
+	{Name: "proxy_endpoint", Type: NetworkProxyEndpointStruct, Nullable: true},
+	{Name: "proxy_http_request", Type: HTTPRequestStruct, Nullable: true},
+	{Name: "proxy_http_response", Type: HTTPResponseStruct, Nullable: true},
+	{Name: "proxy_tls", Type: TransportLayerSecurityTLSStruct, Nullable: true},
+	{Name: "proxy_traffic", Type: NetworkTrafficStruct, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "raw_data_size", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "src_endpoint", Type: NetworkEndpointStruct, Nullable: true},

--- a/ocsf/v1_5_0/group_management.go
+++ b/ocsf/v1_5_0/group_management.go
@@ -10,11 +10,29 @@ import (
 
 type GroupManagement struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
+
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® and ATLAS™ Details: An array of MITRE ATT&CK® objects describing identified tactics, techniques & sub-techniques. The objects are compatible with MITRE ATLAS™ tactics, techniques & sub-techniques.
+	Attacks []MITREATTCKATLAS `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Identity & Access Management</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -28,11 +46,26 @@ type GroupManagement struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
+
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -43,6 +76,9 @@ type GroupManagement struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
 	// Group: Group that was the target of the event.
 	Group Group `json:"group" parquet:"group"`
 
@@ -51,6 +87,15 @@ type GroupManagement struct {
 
 	// HTTP Response: Details about the underlying HTTP response.
 	HttpResponse *HTTPResponse `json:"http_response,omitempty" parquet:"http_response,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
+	// Malware Scan Info: Describes details about the scan job that identified malware on the target system.
+	MalwareScanInfo *MalwareScanInfo `json:"malware_scan_info,omitempty" parquet:"malware_scan_info,optional"`
 
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
@@ -61,8 +106,8 @@ type GroupManagement struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Privileges: A list of privileges assigned to the group.
 	Privileges []string `json:"privileges,omitempty" parquet:"privileges,list,optional"`
@@ -75,6 +120,18 @@ type GroupManagement struct {
 
 	// Resource: Resource that the privileges give access to.
 	Resource *ResourceDetails `json:"resource,omitempty" parquet:"resource,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the <code>severity_id</code> value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -143,28 +200,47 @@ func (v *GroupManagement) ValidateObservables() error {
 }
 
 var GroupManagementFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKATLASStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
 	{Name: "group", Type: GroupStruct, Nullable: false},
 	{Name: "http_request", Type: HTTPRequestStruct, Nullable: true},
 	{Name: "http_response", Type: HTTPResponseStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
+	{Name: "malware_scan_info", Type: MalwareScanInfoStruct, Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "privileges", Type: arrow.ListOf(arrow.BinaryTypes.String), Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "raw_data_size", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "resource", Type: ResourceDetailsStruct, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "src_endpoint", Type: NetworkEndpointStruct, Nullable: true},

--- a/ocsf/v1_5_0/http_activity.go
+++ b/ocsf/v1_5_0/http_activity.go
@@ -10,14 +10,32 @@ import (
 
 type HTTPActivity struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
 
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
 	// Application Name: The name of the application associated with the event or object.
 	AppName *string `json:"app_name,omitempty" parquet:"app_name,optional"`
+
+	// MITRE ATT&CK® and ATLAS™ Details: An array of MITRE ATT&CK® objects describing identified tactics, techniques & sub-techniques. The objects are compatible with MITRE ATLAS™ tactics, techniques & sub-techniques.
+	Attacks []MITREATTCKATLAS `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Network Activity</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -31,14 +49,29 @@ type HTTPActivity struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Connection Info: The network connection information.
 	ConnectionInfo *NetworkConnectionInformation `json:"connection_info,omitempty" parquet:"connection_info,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
+
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Destination Endpoint: The responder (server) in a network connection.
 	DstEndpoint *NetworkEndpoint `json:"dst_endpoint,omitempty" parquet:"dst_endpoint,optional"`
@@ -55,6 +88,9 @@ type HTTPActivity struct {
 	// File: The file that is the target of the HTTP activity.
 	File *File `json:"file,omitempty" parquet:"file,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
 	// HTTP Cookies: The cookies object describes details about HTTP cookies
 	HttpCookies []HTTPCookie `json:"http_cookies,omitempty" parquet:"http_cookies,list,optional"`
 
@@ -64,8 +100,17 @@ type HTTPActivity struct {
 	// HTTP Response: The HTTP Response from a web server to a requester.
 	HttpResponse *HTTPResponse `json:"http_response,omitempty" parquet:"http_response,optional"`
 
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
 	// JA4+ Fingerprints: A list of the JA4+ network fingerprints.
 	Ja4FingerprintList []JA4Fingerprint `json:"ja4_fingerprint_list,omitempty" parquet:"ja4_fingerprint_list,list,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
+	// Malware Scan Info: Describes details about the scan job that identified malware on the target system.
+	MalwareScanInfo *MalwareScanInfo `json:"malware_scan_info,omitempty" parquet:"malware_scan_info,optional"`
 
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
@@ -76,14 +121,44 @@ type HTTPActivity struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
+
+	// Proxy Connection Info: The connection information from the proxy server to the remote server.
+	ProxyConnectionInfo *NetworkConnectionInformation `json:"proxy_connection_info,omitempty" parquet:"proxy_connection_info,optional"`
+
+	// Proxy Endpoint: The proxy (server) in a network connection.
+	ProxyEndpoint *NetworkProxyEndpoint `json:"proxy_endpoint,omitempty" parquet:"proxy_endpoint,optional"`
+
+	// Proxy HTTP Request: The HTTP Request from the proxy server to the remote server.
+	ProxyHttpRequest *HTTPRequest `json:"proxy_http_request,omitempty" parquet:"proxy_http_request,optional"`
+
+	// Proxy HTTP Response: The HTTP Response from the remote server to the proxy server.
+	ProxyHttpResponse *HTTPResponse `json:"proxy_http_response,omitempty" parquet:"proxy_http_response,optional"`
+
+	// Proxy TLS: The TLS protocol negotiated between the proxy server and the remote server.
+	ProxyTls *TransportLayerSecurityTLS `json:"proxy_tls,omitempty" parquet:"proxy_tls,optional"`
+
+	// Proxy Traffic: The network traffic refers to the amount of data moving across a network, from proxy to remote server at a given point of time.
+	ProxyTraffic *NetworkTraffic `json:"proxy_traffic,omitempty" parquet:"proxy_traffic,optional"`
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
 
 	// Raw Data Size: The size of the raw data which was transformed into an OCSF event, in bytes.
 	RawDataSize *int64 `json:"raw_data_size,omitempty" parquet:"raw_data_size,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the <code>severity_id</code> value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -155,31 +230,56 @@ func (v *HTTPActivity) ValidateObservables() error {
 }
 
 var HTTPActivityFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
 	{Name: "app_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKATLASStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "connection_info", Type: NetworkConnectionInformationStruct, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "dst_endpoint", Type: NetworkEndpointStruct, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
 	{Name: "file", Type: FileStruct, Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
 	{Name: "http_cookies", Type: arrow.ListOf(HTTPCookieStruct), Nullable: true},
 	{Name: "http_request", Type: HTTPRequestStruct, Nullable: true},
 	{Name: "http_response", Type: HTTPResponseStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
 	{Name: "ja4_fingerprint_list", Type: arrow.ListOf(JA4FingerprintStruct), Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
+	{Name: "malware_scan_info", Type: MalwareScanInfoStruct, Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
+	{Name: "proxy_connection_info", Type: NetworkConnectionInformationStruct, Nullable: true},
+	{Name: "proxy_endpoint", Type: NetworkProxyEndpointStruct, Nullable: true},
+	{Name: "proxy_http_request", Type: HTTPRequestStruct, Nullable: true},
+	{Name: "proxy_http_response", Type: HTTPResponseStruct, Nullable: true},
+	{Name: "proxy_tls", Type: TransportLayerSecurityTLSStruct, Nullable: true},
+	{Name: "proxy_traffic", Type: NetworkTrafficStruct, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "raw_data_size", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "src_endpoint", Type: NetworkEndpointStruct, Nullable: true},

--- a/ocsf/v1_5_0/incident_finding.go
+++ b/ocsf/v1_5_0/incident_finding.go
@@ -10,11 +10,35 @@ import (
 
 type IncidentFinding struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the Incident activity.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The Incident activity name, as defined by the <code>activity_id</code>.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
+
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// Assignee: The details of the user assigned to an Incident.
+	Assignee *User `json:"assignee,omitempty" parquet:"assignee,optional"`
+
+	// Assignee Group: The details of the group assigned to an Incident.
+	AssigneeGroup *Group `json:"assignee_group,omitempty" parquet:"assignee_group,optional"`
+
+	// MITRE ATT&CK® and ATLAS™ Details: An array of <a target='_blank' href='https://attack.mitre.org'>MITRE ATT&CK®</a> objects describing the tactics, techniques & sub-techniques associated to the Incident.
+	Attacks []MITREATTCKATLAS `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Findings</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -28,17 +52,32 @@ type IncidentFinding struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
-
 	// Comment: Additional user supplied details for updating or closing the incident.
 	Comment *string `json:"comment,omitempty" parquet:"comment,optional"`
+
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
 
 	// Description: The short description of the Incident.
 	Desc *string `json:"desc,omitempty" parquet:"desc,optional"`
+
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -52,6 +91,30 @@ type IncidentFinding struct {
 	// Finding Information List: A list of <code>finding_info</code> objects associated to an incident.
 	FindingInfoList []FindingInformation `json:"finding_info_list" parquet:"finding_info_list,list"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Impact: The impact , normalized to the caption of the impact_id value. In the case of 'Other', it is defined by the event source.
+	Impact *string `json:"impact,omitempty" parquet:"impact,optional"`
+
+	// Impact ID: The normalized impact of the incident or finding. Per NIST, this is the magnitude of harm that can be expected to result from the consequences of unauthorized disclosure, modification, destruction, or loss of information or information system availability.
+	ImpactId *int32 `json:"impact_id,omitempty" parquet:"impact_id,optional"`
+
+	// Impact Score: The impact as an integer value of the finding, valid range 0-100.
+	ImpactScore *int32 `json:"impact_score,omitempty" parquet:"impact_score,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Suspected Breach: A determination based on analytics as to whether a potential breach was found.
+	IsSuspectedBreach *bool `json:"is_suspected_breach,omitempty" parquet:"is_suspected_breach,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
+	// Malware Scan Info: Describes details about the scan job that identified malware on the target system.
+	MalwareScanInfo *MalwareScanInfo `json:"malware_scan_info,omitempty" parquet:"malware_scan_info,optional"`
+
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
 
@@ -61,8 +124,14 @@ type IncidentFinding struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
+
+	// Priority: The priority, normalized to the caption of the priority_id value. In the case of 'Other', it is defined by the event source.
+	Priority *string `json:"priority,omitempty" parquet:"priority,optional"`
+
+	// Priority ID: The normalized priority. Priority identifies the relative importance of the incident or finding. It is a measurement of urgency.
+	PriorityId *int32 `json:"priority_id,omitempty" parquet:"priority_id,optional"`
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
@@ -70,11 +139,26 @@ type IncidentFinding struct {
 	// Raw Data Size: The size of the raw data which was transformed into an OCSF event, in bytes.
 	RawDataSize *int64 `json:"raw_data_size,omitempty" parquet:"raw_data_size,optional"`
 
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
+
 	// Severity: The event/finding severity, normalized to the caption of the <code>severity_id</code> value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
 
 	// Severity ID: <p>The normalized identifier of the event/finding severity.</p>The normalized severity is a measurement the effort and expense required to manage and resolve an event or incident. Smaller numerical values represent lower impact events, and larger numerical values represent higher impact events.
 	SeverityId int32 `json:"severity_id" parquet:"severity_id"`
+
+	// Source URL: A Url link used to access the original incident.
+	SrcUrl *string `json:"src_url,omitempty" parquet:"src_url,optional"`
 
 	// Start Time: The time of the least recent event included in the incident.
 	StartTime int64 `json:"start_time,omitempty" parquet:"start_time,timestamp_millis,timestamp(millisecond),optional"`
@@ -90,6 +174,9 @@ type IncidentFinding struct {
 
 	// Status ID: The normalized status identifier of the Incident.
 	StatusId int32 `json:"status_id" parquet:"status_id"`
+
+	// Tickets: The associated ticket(s) in the ticketing system. Each ticket contains details like ticket ID, status, etc.
+	Tickets []Ticket `json:"tickets,omitempty" parquet:"tickets,list,optional"`
 
 	// Event Time: The normalized event occurrence time or the finding creation time.
 	Time int64 `json:"time" parquet:"time,timestamp_millis,timestamp(millisecond)"`
@@ -108,6 +195,12 @@ type IncidentFinding struct {
 
 	// Vendor Attributes: The Vendor Attributes object can be used to represent values of attributes populated by the Vendor/Finding Provider. It can help distinguish between the vendor-prodvided values and consumer-updated values, of key attributes like <code>severity_id</code>.<br>The original finding producer should not populate this object. It should be populated by consuming systems that support data mutability.
 	VendorAttributes *VendorAttributes `json:"vendor_attributes,omitempty" parquet:"vendor_attributes,optional"`
+
+	// Verdict: The verdict assigned to an Incident finding.
+	Verdict *string `json:"verdict,omitempty" parquet:"verdict,optional"`
+
+	// Verdict ID: The normalized verdict of an Incident.
+	VerdictId *int32 `json:"verdict_id,omitempty" parquet:"verdict_id,optional"`
 }
 
 func (v *IncidentFinding) Observable() (*int, string) {
@@ -134,39 +227,70 @@ func (v *IncidentFinding) ValidateObservables() error {
 }
 
 var IncidentFindingFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "assignee", Type: UserStruct, Nullable: true},
+	{Name: "assignee_group", Type: GroupStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKATLASStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
 	{Name: "comment", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "desc", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
 	{Name: "finding_info_list", Type: arrow.ListOf(FindingInformationStruct), Nullable: false},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "impact", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "impact_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "impact_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "is_suspected_breach", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
+	{Name: "malware_scan_info", Type: MalwareScanInfoStruct, Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
+	{Name: "priority", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "priority_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "raw_data_size", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
+	{Name: "src_url", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "start_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "status", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "status_code", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "status_detail", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "status_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
+	{Name: "tickets", Type: arrow.ListOf(TicketStruct), Nullable: true},
 	{Name: "time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: false},
 	{Name: "timezone_offset", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "type_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "type_uid", Type: arrow.PrimitiveTypes.Int64, Nullable: false},
 	{Name: "unmapped", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "vendor_attributes", Type: VendorAttributesStruct, Nullable: true},
+	{Name: "verdict", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "verdict_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 }
 
 var IncidentFindingStruct = arrow.StructOf(IncidentFindingFields...)

--- a/ocsf/v1_5_0/inventory_info.go
+++ b/ocsf/v1_5_0/inventory_info.go
@@ -10,11 +10,29 @@ import (
 
 type DeviceInventoryInfo struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
+
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® and ATLAS™ Details: An array of MITRE ATT&CK® objects describing identified tactics, techniques & sub-techniques. The objects are compatible with MITRE ATLAS™ tactics, techniques & sub-techniques.
+	Attacks []MITREATTCKATLAS `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Discovery</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -28,14 +46,26 @@ type DeviceInventoryInfo struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
 
 	// Device: The device that is being discovered by an inventory process.
 	Device Device `json:"device" parquet:"device"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -46,6 +76,18 @@ type DeviceInventoryInfo struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
+	// Malware Scan Info: Describes details about the scan job that identified malware on the target system.
+	MalwareScanInfo *MalwareScanInfo `json:"malware_scan_info,omitempty" parquet:"malware_scan_info,optional"`
+
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
 
@@ -55,14 +97,26 @@ type DeviceInventoryInfo struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
 
 	// Raw Data Size: The size of the raw data which was transformed into an OCSF event, in bytes.
 	RawDataSize *int64 `json:"raw_data_size,omitempty" parquet:"raw_data_size,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the <code>severity_id</code> value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -125,24 +179,42 @@ func (v *DeviceInventoryInfo) ValidateObservables() error {
 }
 
 var DeviceInventoryInfoFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKATLASStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "device", Type: DeviceStruct, Nullable: false},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
+	{Name: "malware_scan_info", Type: MalwareScanInfoStruct, Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "raw_data_size", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "start_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},

--- a/ocsf/v1_5_0/job_query.go
+++ b/ocsf/v1_5_0/job_query.go
@@ -10,11 +10,29 @@ import (
 
 type JobQuery struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
+
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® and ATLAS™ Details: An array of MITRE ATT&CK® objects describing identified tactics, techniques & sub-techniques. The objects are compatible with MITRE ATLAS™ tactics, techniques & sub-techniques.
+	Attacks []MITREATTCKATLAS `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Discovery</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -28,11 +46,26 @@ type JobQuery struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
+
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -43,8 +76,20 @@ type JobQuery struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
 	// Job: The job object that pertains to the event.
 	Job Job `json:"job" parquet:"job"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
+	// Malware Scan Info: Describes details about the scan job that identified malware on the target system.
+	MalwareScanInfo *MalwareScanInfo `json:"malware_scan_info,omitempty" parquet:"malware_scan_info,optional"`
 
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
@@ -55,8 +100,8 @@ type JobQuery struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Query Info: The search details associated with the query request.
 	QueryInfo *QueryInformation `json:"query_info,omitempty" parquet:"query_info,optional"`
@@ -72,6 +117,18 @@ type JobQuery struct {
 
 	// Raw Data Size: The size of the raw data which was transformed into an OCSF event, in bytes.
 	RawDataSize *int64 `json:"raw_data_size,omitempty" parquet:"raw_data_size,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the <code>severity_id</code> value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -134,27 +191,46 @@ func (v *JobQuery) ValidateObservables() error {
 }
 
 var JobQueryFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKATLASStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
 	{Name: "job", Type: JobStruct, Nullable: false},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
+	{Name: "malware_scan_info", Type: MalwareScanInfoStruct, Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "query_info", Type: QueryInformationStruct, Nullable: true},
 	{Name: "query_result", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "query_result_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "raw_data_size", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "start_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},

--- a/ocsf/v1_5_0/kernel_activity.go
+++ b/ocsf/v1_5_0/kernel_activity.go
@@ -10,6 +10,12 @@ import (
 
 type KernelActivity struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
@@ -18,6 +24,15 @@ type KernelActivity struct {
 
 	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
 	Actor Actor `json:"actor" parquet:"actor"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® and ATLAS™ Details: An array of MITRE ATT&CK® objects describing identified tactics, techniques & sub-techniques. The objects are compatible with MITRE ATLAS™ tactics, techniques & sub-techniques.
+	Attacks []MITREATTCKATLAS `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>System Activity</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -31,14 +46,26 @@ type KernelActivity struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
 
 	// Device: An addressable device, computer system or host.
 	Device Device `json:"device" parquet:"device"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -49,8 +76,20 @@ type KernelActivity struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
 	// Kernel: The target kernel resource.
 	Kernel KernelResource `json:"kernel" parquet:"kernel"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
+	// Malware Scan Info: Describes details about the scan job that identified malware on the target system.
+	MalwareScanInfo *MalwareScanInfo `json:"malware_scan_info,omitempty" parquet:"malware_scan_info,optional"`
 
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
@@ -61,14 +100,26 @@ type KernelActivity struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
 
 	// Raw Data Size: The size of the raw data which was transformed into an OCSF event, in bytes.
 	RawDataSize *int64 `json:"raw_data_size,omitempty" parquet:"raw_data_size,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the <code>severity_id</code> value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -131,26 +182,43 @@ func (v *KernelActivity) ValidateObservables() error {
 }
 
 var KernelActivityFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "actor", Type: ActorStruct, Nullable: false},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKATLASStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "device", Type: DeviceStruct, Nullable: false},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
 	{Name: "kernel", Type: KernelResourceStruct, Nullable: false},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
+	{Name: "malware_scan_info", Type: MalwareScanInfoStruct, Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "raw_data_size", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "start_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},

--- a/ocsf/v1_5_0/kernel_extension_activity.go
+++ b/ocsf/v1_5_0/kernel_extension_activity.go
@@ -10,6 +10,12 @@ import (
 
 type KernelExtensionActivity struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
@@ -18,6 +24,15 @@ type KernelExtensionActivity struct {
 
 	// Actor: The actor process that loaded or unloaded the driver/extension.
 	Actor Actor `json:"actor" parquet:"actor"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® and ATLAS™ Details: An array of MITRE ATT&CK® objects describing identified tactics, techniques & sub-techniques. The objects are compatible with MITRE ATLAS™ tactics, techniques & sub-techniques.
+	Attacks []MITREATTCKATLAS `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>System Activity</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -31,14 +46,26 @@ type KernelExtensionActivity struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
 
 	// Device: An addressable device, computer system or host.
 	Device Device `json:"device" parquet:"device"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Kernel Driver: The driver that was loaded/unloaded into the kernel
 	Driver KernelExtension `json:"driver" parquet:"driver"`
@@ -52,6 +79,18 @@ type KernelExtensionActivity struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
+	// Malware Scan Info: Describes details about the scan job that identified malware on the target system.
+	MalwareScanInfo *MalwareScanInfo `json:"malware_scan_info,omitempty" parquet:"malware_scan_info,optional"`
+
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
 
@@ -61,14 +100,26 @@ type KernelExtensionActivity struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
 
 	// Raw Data Size: The size of the raw data which was transformed into an OCSF event, in bytes.
 	RawDataSize *int64 `json:"raw_data_size,omitempty" parquet:"raw_data_size,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the <code>severity_id</code> value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -131,26 +182,43 @@ func (v *KernelExtensionActivity) ValidateObservables() error {
 }
 
 var KernelExtensionActivityFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "actor", Type: ActorStruct, Nullable: false},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKATLASStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "device", Type: DeviceStruct, Nullable: false},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "driver", Type: KernelExtensionStruct, Nullable: false},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
+	{Name: "malware_scan_info", Type: MalwareScanInfoStruct, Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "raw_data_size", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "start_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},

--- a/ocsf/v1_5_0/kernel_object_query.go
+++ b/ocsf/v1_5_0/kernel_object_query.go
@@ -10,11 +10,29 @@ import (
 
 type KernelObjectQuery struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
+
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® and ATLAS™ Details: An array of MITRE ATT&CK® objects describing identified tactics, techniques & sub-techniques. The objects are compatible with MITRE ATLAS™ tactics, techniques & sub-techniques.
+	Attacks []MITREATTCKATLAS `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Discovery</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -28,11 +46,26 @@ type KernelObjectQuery struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
+
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -43,8 +76,20 @@ type KernelObjectQuery struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
 	// Kernel: The kernel object that pertains to the event.
 	Kernel KernelResource `json:"kernel" parquet:"kernel"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
+	// Malware Scan Info: Describes details about the scan job that identified malware on the target system.
+	MalwareScanInfo *MalwareScanInfo `json:"malware_scan_info,omitempty" parquet:"malware_scan_info,optional"`
 
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
@@ -55,8 +100,8 @@ type KernelObjectQuery struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Query Info: The search details associated with the query request.
 	QueryInfo *QueryInformation `json:"query_info,omitempty" parquet:"query_info,optional"`
@@ -72,6 +117,18 @@ type KernelObjectQuery struct {
 
 	// Raw Data Size: The size of the raw data which was transformed into an OCSF event, in bytes.
 	RawDataSize *int64 `json:"raw_data_size,omitempty" parquet:"raw_data_size,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the <code>severity_id</code> value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -134,27 +191,46 @@ func (v *KernelObjectQuery) ValidateObservables() error {
 }
 
 var KernelObjectQueryFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKATLASStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
 	{Name: "kernel", Type: KernelResourceStruct, Nullable: false},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
+	{Name: "malware_scan_info", Type: MalwareScanInfoStruct, Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "query_info", Type: QueryInformationStruct, Nullable: true},
 	{Name: "query_result", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "query_result_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "raw_data_size", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "start_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},

--- a/ocsf/v1_5_0/memory_activity.go
+++ b/ocsf/v1_5_0/memory_activity.go
@@ -10,6 +10,12 @@ import (
 
 type MemoryActivity struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
@@ -21,6 +27,15 @@ type MemoryActivity struct {
 
 	// Actual Permissions: The permissions that were granted to access memory.
 	ActualPermissions *int32 `json:"actual_permissions,omitempty" parquet:"actual_permissions,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® and ATLAS™ Details: An array of MITRE ATT&CK® objects describing identified tactics, techniques & sub-techniques. The objects are compatible with MITRE ATLAS™ tactics, techniques & sub-techniques.
+	Attacks []MITREATTCKATLAS `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Base Address: The memory address that was access or requested.
 	BaseAddress *string `json:"base_address,omitempty" parquet:"base_address,optional"`
@@ -37,14 +52,26 @@ type MemoryActivity struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
 
 	// Device: An addressable device, computer system or host.
 	Device Device `json:"device" parquet:"device"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -55,6 +82,18 @@ type MemoryActivity struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
+	// Malware Scan Info: Describes details about the scan job that identified malware on the target system.
+	MalwareScanInfo *MalwareScanInfo `json:"malware_scan_info,omitempty" parquet:"malware_scan_info,optional"`
+
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
 
@@ -64,8 +103,8 @@ type MemoryActivity struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Process: The process that had memory allocated, read/written, or had other manipulation activities performed on it.
 	Process Process `json:"process" parquet:"process"`
@@ -78,6 +117,18 @@ type MemoryActivity struct {
 
 	// Requested Permissions: The permissions mask that was requested to access memory.
 	RequestedPermissions *int32 `json:"requested_permissions,omitempty" parquet:"requested_permissions,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the <code>severity_id</code> value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -143,29 +194,46 @@ func (v *MemoryActivity) ValidateObservables() error {
 }
 
 var MemoryActivityFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "actor", Type: ActorStruct, Nullable: false},
 	{Name: "actual_permissions", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKATLASStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "base_address", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "device", Type: DeviceStruct, Nullable: false},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
+	{Name: "malware_scan_info", Type: MalwareScanInfoStruct, Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "process", Type: ProcessStruct, Nullable: false},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "raw_data_size", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "requested_permissions", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "size", Type: arrow.PrimitiveTypes.Int64, Nullable: true},

--- a/ocsf/v1_5_0/module_activity.go
+++ b/ocsf/v1_5_0/module_activity.go
@@ -10,6 +10,12 @@ import (
 
 type ModuleActivity struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
@@ -18,6 +24,15 @@ type ModuleActivity struct {
 
 	// Actor: The actor that loaded or unloaded the <code>module</code>.
 	Actor Actor `json:"actor" parquet:"actor"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® and ATLAS™ Details: An array of MITRE ATT&CK® objects describing identified tactics, techniques & sub-techniques. The objects are compatible with MITRE ATLAS™ tactics, techniques & sub-techniques.
+	Attacks []MITREATTCKATLAS `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>System Activity</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -31,14 +46,26 @@ type ModuleActivity struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
 
 	// Device: An addressable device, computer system or host.
 	Device Device `json:"device" parquet:"device"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -48,6 +75,18 @@ type ModuleActivity struct {
 
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
+
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
+	// Malware Scan Info: Describes details about the scan job that identified malware on the target system.
+	MalwareScanInfo *MalwareScanInfo `json:"malware_scan_info,omitempty" parquet:"malware_scan_info,optional"`
 
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
@@ -61,14 +100,26 @@ type ModuleActivity struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
 
 	// Raw Data Size: The size of the raw data which was transformed into an OCSF event, in bytes.
 	RawDataSize *int64 `json:"raw_data_size,omitempty" parquet:"raw_data_size,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the <code>severity_id</code> value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -131,26 +182,43 @@ func (v *ModuleActivity) ValidateObservables() error {
 }
 
 var ModuleActivityFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "actor", Type: ActorStruct, Nullable: false},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKATLASStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "device", Type: DeviceStruct, Nullable: false},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
+	{Name: "malware_scan_info", Type: MalwareScanInfoStruct, Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "module", Type: ModuleStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "raw_data_size", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "start_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},

--- a/ocsf/v1_5_0/module_query.go
+++ b/ocsf/v1_5_0/module_query.go
@@ -10,11 +10,29 @@ import (
 
 type ModuleQuery struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
+
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® and ATLAS™ Details: An array of MITRE ATT&CK® objects describing identified tactics, techniques & sub-techniques. The objects are compatible with MITRE ATLAS™ tactics, techniques & sub-techniques.
+	Attacks []MITREATTCKATLAS `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Discovery</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -28,11 +46,26 @@ type ModuleQuery struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
+
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -42,6 +75,18 @@ type ModuleQuery struct {
 
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
+
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
+	// Malware Scan Info: Describes details about the scan job that identified malware on the target system.
+	MalwareScanInfo *MalwareScanInfo `json:"malware_scan_info,omitempty" parquet:"malware_scan_info,optional"`
 
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
@@ -55,8 +100,8 @@ type ModuleQuery struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Process: The process that loaded the module.
 	Process Process `json:"process" parquet:"process"`
@@ -75,6 +120,18 @@ type ModuleQuery struct {
 
 	// Raw Data Size: The size of the raw data which was transformed into an OCSF event, in bytes.
 	RawDataSize *int64 `json:"raw_data_size,omitempty" parquet:"raw_data_size,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the <code>severity_id</code> value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -137,28 +194,47 @@ func (v *ModuleQuery) ValidateObservables() error {
 }
 
 var ModuleQueryFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKATLASStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
+	{Name: "malware_scan_info", Type: MalwareScanInfoStruct, Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "module", Type: ModuleStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "process", Type: ProcessStruct, Nullable: false},
 	{Name: "query_info", Type: QueryInformationStruct, Nullable: true},
 	{Name: "query_result", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "query_result_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "raw_data_size", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "start_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},

--- a/ocsf/v1_5_0/network_activity.go
+++ b/ocsf/v1_5_0/network_activity.go
@@ -10,14 +10,32 @@ import (
 
 type NetworkActivity struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
 
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
 	// Application Name: The name of the application associated with the event or object.
 	AppName *string `json:"app_name,omitempty" parquet:"app_name,optional"`
+
+	// MITRE ATT&CK® and ATLAS™ Details: An array of MITRE ATT&CK® objects describing identified tactics, techniques & sub-techniques. The objects are compatible with MITRE ATLAS™ tactics, techniques & sub-techniques.
+	Attacks []MITREATTCKATLAS `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Network Activity</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -31,14 +49,29 @@ type NetworkActivity struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Connection Info: The network connection information.
 	ConnectionInfo *NetworkConnectionInformation `json:"connection_info,omitempty" parquet:"connection_info,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
+
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Destination Endpoint: The responder (server) in a network connection.
 	DstEndpoint *NetworkEndpoint `json:"dst_endpoint,omitempty" parquet:"dst_endpoint,optional"`
@@ -52,8 +85,20 @@ type NetworkActivity struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
 	// JA4+ Fingerprints: A list of the JA4+ network fingerprints.
 	Ja4FingerprintList []JA4Fingerprint `json:"ja4_fingerprint_list,omitempty" parquet:"ja4_fingerprint_list,list,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
+	// Malware Scan Info: Describes details about the scan job that identified malware on the target system.
+	MalwareScanInfo *MalwareScanInfo `json:"malware_scan_info,omitempty" parquet:"malware_scan_info,optional"`
 
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
@@ -64,14 +109,44 @@ type NetworkActivity struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
+
+	// Proxy Connection Info: The connection information from the proxy server to the remote server.
+	ProxyConnectionInfo *NetworkConnectionInformation `json:"proxy_connection_info,omitempty" parquet:"proxy_connection_info,optional"`
+
+	// Proxy Endpoint: The proxy (server) in a network connection.
+	ProxyEndpoint *NetworkProxyEndpoint `json:"proxy_endpoint,omitempty" parquet:"proxy_endpoint,optional"`
+
+	// Proxy HTTP Request: The HTTP Request from the proxy server to the remote server.
+	ProxyHttpRequest *HTTPRequest `json:"proxy_http_request,omitempty" parquet:"proxy_http_request,optional"`
+
+	// Proxy HTTP Response: The HTTP Response from the remote server to the proxy server.
+	ProxyHttpResponse *HTTPResponse `json:"proxy_http_response,omitempty" parquet:"proxy_http_response,optional"`
+
+	// Proxy TLS: The TLS protocol negotiated between the proxy server and the remote server.
+	ProxyTls *TransportLayerSecurityTLS `json:"proxy_tls,omitempty" parquet:"proxy_tls,optional"`
+
+	// Proxy Traffic: The network traffic refers to the amount of data moving across a network, from proxy to remote server at a given point of time.
+	ProxyTraffic *NetworkTraffic `json:"proxy_traffic,omitempty" parquet:"proxy_traffic,optional"`
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
 
 	// Raw Data Size: The size of the raw data which was transformed into an OCSF event, in bytes.
 	RawDataSize *int64 `json:"raw_data_size,omitempty" parquet:"raw_data_size,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the <code>severity_id</code> value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -146,27 +221,52 @@ func (v *NetworkActivity) ValidateObservables() error {
 }
 
 var NetworkActivityFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
 	{Name: "app_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKATLASStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "connection_info", Type: NetworkConnectionInformationStruct, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "dst_endpoint", Type: NetworkEndpointStruct, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
 	{Name: "ja4_fingerprint_list", Type: arrow.ListOf(JA4FingerprintStruct), Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
+	{Name: "malware_scan_info", Type: MalwareScanInfoStruct, Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
+	{Name: "proxy_connection_info", Type: NetworkConnectionInformationStruct, Nullable: true},
+	{Name: "proxy_endpoint", Type: NetworkProxyEndpointStruct, Nullable: true},
+	{Name: "proxy_http_request", Type: HTTPRequestStruct, Nullable: true},
+	{Name: "proxy_http_response", Type: HTTPResponseStruct, Nullable: true},
+	{Name: "proxy_tls", Type: TransportLayerSecurityTLSStruct, Nullable: true},
+	{Name: "proxy_traffic", Type: NetworkTrafficStruct, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "raw_data_size", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "src_endpoint", Type: NetworkEndpointStruct, Nullable: true},

--- a/ocsf/v1_5_0/network_connection_query.go
+++ b/ocsf/v1_5_0/network_connection_query.go
@@ -10,11 +10,29 @@ import (
 
 type NetworkConnectionQuery struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
+
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® and ATLAS™ Details: An array of MITRE ATT&CK® objects describing identified tactics, techniques & sub-techniques. The objects are compatible with MITRE ATLAS™ tactics, techniques & sub-techniques.
+	Attacks []MITREATTCKATLAS `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Discovery</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -28,14 +46,29 @@ type NetworkConnectionQuery struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Connection Info: The network connection information.
 	ConnectionInfo NetworkConnectionInformation `json:"connection_info" parquet:"connection_info"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
+
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -46,6 +79,18 @@ type NetworkConnectionQuery struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
+	// Malware Scan Info: Describes details about the scan job that identified malware on the target system.
+	MalwareScanInfo *MalwareScanInfo `json:"malware_scan_info,omitempty" parquet:"malware_scan_info,optional"`
+
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
 
@@ -55,8 +100,8 @@ type NetworkConnectionQuery struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Process: The process that owns the socket.
 	Process Process `json:"process" parquet:"process"`
@@ -75,6 +120,18 @@ type NetworkConnectionQuery struct {
 
 	// Raw Data Size: The size of the raw data which was transformed into an OCSF event, in bytes.
 	RawDataSize *int64 `json:"raw_data_size,omitempty" parquet:"raw_data_size,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the <code>severity_id</code> value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -143,28 +200,47 @@ func (v *NetworkConnectionQuery) ValidateObservables() error {
 }
 
 var NetworkConnectionQueryFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKATLASStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "connection_info", Type: NetworkConnectionInformationStruct, Nullable: false},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
+	{Name: "malware_scan_info", Type: MalwareScanInfoStruct, Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "process", Type: ProcessStruct, Nullable: false},
 	{Name: "query_info", Type: QueryInformationStruct, Nullable: true},
 	{Name: "query_result", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "query_result_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "raw_data_size", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "start_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},

--- a/ocsf/v1_5_0/network_file_activity.go
+++ b/ocsf/v1_5_0/network_file_activity.go
@@ -10,6 +10,12 @@ import (
 
 type NetworkFileActivity struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
@@ -19,8 +25,17 @@ type NetworkFileActivity struct {
 	// Actor: The actor that performed the activity on the target file.
 	Actor Actor `json:"actor" parquet:"actor"`
 
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
 	// Application Name: The name of the application associated with the event or object.
 	AppName *string `json:"app_name,omitempty" parquet:"app_name,optional"`
+
+	// MITRE ATT&CK® and ATLAS™ Details: An array of MITRE ATT&CK® objects describing identified tactics, techniques & sub-techniques. The objects are compatible with MITRE ATLAS™ tactics, techniques & sub-techniques.
+	Attacks []MITREATTCKATLAS `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Network Activity</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -34,14 +49,29 @@ type NetworkFileActivity struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Connection Info: The network connection information.
 	ConnectionInfo *NetworkConnectionInformation `json:"connection_info,omitempty" parquet:"connection_info,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
+
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Destination Endpoint: The endpoint that received the activity on the target file.
 	DstEndpoint *NetworkEndpoint `json:"dst_endpoint,omitempty" parquet:"dst_endpoint,optional"`
@@ -61,8 +91,20 @@ type NetworkFileActivity struct {
 	// File: The file that is the target of the activity.
 	File File `json:"file" parquet:"file"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
 	// JA4+ Fingerprints: A list of the JA4+ network fingerprints.
 	Ja4FingerprintList []JA4Fingerprint `json:"ja4_fingerprint_list,omitempty" parquet:"ja4_fingerprint_list,list,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
+	// Malware Scan Info: Describes details about the scan job that identified malware on the target system.
+	MalwareScanInfo *MalwareScanInfo `json:"malware_scan_info,omitempty" parquet:"malware_scan_info,optional"`
 
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
@@ -73,14 +115,44 @@ type NetworkFileActivity struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
+
+	// Proxy Connection Info: The connection information from the proxy server to the remote server.
+	ProxyConnectionInfo *NetworkConnectionInformation `json:"proxy_connection_info,omitempty" parquet:"proxy_connection_info,optional"`
+
+	// Proxy Endpoint: The proxy (server) in a network connection.
+	ProxyEndpoint *NetworkProxyEndpoint `json:"proxy_endpoint,omitempty" parquet:"proxy_endpoint,optional"`
+
+	// Proxy HTTP Request: The HTTP Request from the proxy server to the remote server.
+	ProxyHttpRequest *HTTPRequest `json:"proxy_http_request,omitempty" parquet:"proxy_http_request,optional"`
+
+	// Proxy HTTP Response: The HTTP Response from the remote server to the proxy server.
+	ProxyHttpResponse *HTTPResponse `json:"proxy_http_response,omitempty" parquet:"proxy_http_response,optional"`
+
+	// Proxy TLS: The TLS protocol negotiated between the proxy server and the remote server.
+	ProxyTls *TransportLayerSecurityTLS `json:"proxy_tls,omitempty" parquet:"proxy_tls,optional"`
+
+	// Proxy Traffic: The network traffic refers to the amount of data moving across a network, from proxy to remote server at a given point of time.
+	ProxyTraffic *NetworkTraffic `json:"proxy_traffic,omitempty" parquet:"proxy_traffic,optional"`
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
 
 	// Raw Data Size: The size of the raw data which was transformed into an OCSF event, in bytes.
 	RawDataSize *int64 `json:"raw_data_size,omitempty" parquet:"raw_data_size,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the <code>severity_id</code> value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -152,30 +224,54 @@ func (v *NetworkFileActivity) ValidateObservables() error {
 }
 
 var NetworkFileActivityFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "actor", Type: ActorStruct, Nullable: false},
+	{Name: "api", Type: APIStruct, Nullable: true},
 	{Name: "app_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKATLASStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "connection_info", Type: NetworkConnectionInformationStruct, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "dst_endpoint", Type: NetworkEndpointStruct, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
 	{Name: "expiration_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "file", Type: FileStruct, Nullable: false},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
 	{Name: "ja4_fingerprint_list", Type: arrow.ListOf(JA4FingerprintStruct), Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
+	{Name: "malware_scan_info", Type: MalwareScanInfoStruct, Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
+	{Name: "proxy_connection_info", Type: NetworkConnectionInformationStruct, Nullable: true},
+	{Name: "proxy_endpoint", Type: NetworkProxyEndpointStruct, Nullable: true},
+	{Name: "proxy_http_request", Type: HTTPRequestStruct, Nullable: true},
+	{Name: "proxy_http_response", Type: HTTPResponseStruct, Nullable: true},
+	{Name: "proxy_tls", Type: TransportLayerSecurityTLSStruct, Nullable: true},
+	{Name: "proxy_traffic", Type: NetworkTrafficStruct, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "raw_data_size", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "src_endpoint", Type: NetworkEndpointStruct, Nullable: false},

--- a/ocsf/v1_5_0/network_remediation_activity.go
+++ b/ocsf/v1_5_0/network_remediation_activity.go
@@ -10,11 +10,29 @@ import (
 
 type NetworkRemediationActivity struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: Matches the MITRE D3FEND™ Tactic. Note: the Model and Detect Tactics are not supported as remediations by the OCSF Remediation event class.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
+
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® and ATLAS™ Details: An array of MITRE ATT&CK® objects describing identified tactics, techniques & sub-techniques. The objects are compatible with MITRE ATLAS™ tactics, techniques & sub-techniques.
+	Attacks []MITREATTCKATLAS `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Remediation</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -28,11 +46,17 @@ type NetworkRemediationActivity struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
-
 	// Command UID: The unique identifier of the remediation command that pertains to this event.
 	CommandUid string `json:"command_uid" parquet:"command_uid"`
+
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Connection Info: The network connection that pertains to the remediation event.
 	ConnectionInfo NetworkConnectionInformation `json:"connection_info" parquet:"connection_info"`
@@ -43,6 +67,15 @@ type NetworkRemediationActivity struct {
 	// Countermeasures: The MITRE D3FEND™ Matrix Countermeasures associated with a remediation.
 	Countermeasures []MITRED3FEND `json:"countermeasures,omitempty" parquet:"countermeasures,list,optional"`
 
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
+
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
 
@@ -51,6 +84,18 @@ type NetworkRemediationActivity struct {
 
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
+
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
+	// Malware Scan Info: Describes details about the scan job that identified malware on the target system.
+	MalwareScanInfo *MalwareScanInfo `json:"malware_scan_info,omitempty" parquet:"malware_scan_info,optional"`
 
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
@@ -61,8 +106,8 @@ type NetworkRemediationActivity struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
@@ -72,6 +117,18 @@ type NetworkRemediationActivity struct {
 
 	// Remediation Guidance: Describes the recommended remediation steps to address identified issue(s).
 	Remediation *Remediation `json:"remediation,omitempty" parquet:"remediation,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Scan: The remediation scan that pertains to this event.
 	Scan *Scan `json:"scan,omitempty" parquet:"scan,optional"`
@@ -137,27 +194,46 @@ func (v *NetworkRemediationActivity) ValidateObservables() error {
 }
 
 var NetworkRemediationActivityFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKATLASStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
 	{Name: "command_uid", Type: arrow.BinaryTypes.String, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "connection_info", Type: NetworkConnectionInformationStruct, Nullable: false},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "countermeasures", Type: arrow.ListOf(MITRED3FENDStruct), Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
+	{Name: "malware_scan_info", Type: MalwareScanInfoStruct, Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "raw_data_size", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "remediation", Type: RemediationStruct, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "scan", Type: ScanStruct, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},

--- a/ocsf/v1_5_0/networks_query.go
+++ b/ocsf/v1_5_0/networks_query.go
@@ -10,11 +10,29 @@ import (
 
 type NetworksQuery struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
+
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® and ATLAS™ Details: An array of MITRE ATT&CK® objects describing identified tactics, techniques & sub-techniques. The objects are compatible with MITRE ATLAS™ tactics, techniques & sub-techniques.
+	Attacks []MITREATTCKATLAS `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Discovery</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -28,11 +46,26 @@ type NetworksQuery struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
+
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -42,6 +75,18 @@ type NetworksQuery struct {
 
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
+
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
+	// Malware Scan Info: Describes details about the scan job that identified malware on the target system.
+	MalwareScanInfo *MalwareScanInfo `json:"malware_scan_info,omitempty" parquet:"malware_scan_info,optional"`
 
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
@@ -55,8 +100,8 @@ type NetworksQuery struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Query Info: The search details associated with the query request.
 	QueryInfo *QueryInformation `json:"query_info,omitempty" parquet:"query_info,optional"`
@@ -72,6 +117,18 @@ type NetworksQuery struct {
 
 	// Raw Data Size: The size of the raw data which was transformed into an OCSF event, in bytes.
 	RawDataSize *int64 `json:"raw_data_size,omitempty" parquet:"raw_data_size,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the <code>severity_id</code> value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -134,27 +191,46 @@ func (v *NetworksQuery) ValidateObservables() error {
 }
 
 var NetworksQueryFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKATLASStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
+	{Name: "malware_scan_info", Type: MalwareScanInfoStruct, Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "network_interfaces", Type: arrow.ListOf(NetworkInterfaceStruct), Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "query_info", Type: QueryInformationStruct, Nullable: true},
 	{Name: "query_result", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "query_result_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "raw_data_size", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "start_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},

--- a/ocsf/v1_5_0/ntp_activity.go
+++ b/ocsf/v1_5_0/ntp_activity.go
@@ -10,14 +10,32 @@ import (
 
 type NTPActivity struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
 
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
 	// Application Name: The name of the application associated with the event or object.
 	AppName *string `json:"app_name,omitempty" parquet:"app_name,optional"`
+
+	// MITRE ATT&CK® and ATLAS™ Details: An array of MITRE ATT&CK® objects describing identified tactics, techniques & sub-techniques. The objects are compatible with MITRE ATLAS™ tactics, techniques & sub-techniques.
+	Attacks []MITREATTCKATLAS `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Network Activity</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -31,8 +49,14 @@ type NTPActivity struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Connection Info: The network connection information.
 	ConnectionInfo *NetworkConnectionInformation `json:"connection_info,omitempty" parquet:"connection_info,optional"`
@@ -43,8 +67,17 @@ type NTPActivity struct {
 	// Root Delay: The total round-trip delay to the reference clock in milliseconds.
 	Delay *int32 `json:"delay,omitempty" parquet:"delay,optional"`
 
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
 	// Root Dispersion: The dispersion in the NTP protocol is the estimated time error or uncertainty relative to the reference clock in milliseconds.
 	Dispersion *int32 `json:"dispersion,omitempty" parquet:"dispersion,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Destination Endpoint: The responder (server) in a network connection.
 	DstEndpoint *NetworkEndpoint `json:"dst_endpoint,omitempty" parquet:"dst_endpoint,optional"`
@@ -58,8 +91,20 @@ type NTPActivity struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
 	// JA4+ Fingerprints: A list of the JA4+ network fingerprints.
 	Ja4FingerprintList []JA4Fingerprint `json:"ja4_fingerprint_list,omitempty" parquet:"ja4_fingerprint_list,list,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
+	// Malware Scan Info: Describes details about the scan job that identified malware on the target system.
+	MalwareScanInfo *MalwareScanInfo `json:"malware_scan_info,omitempty" parquet:"malware_scan_info,optional"`
 
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
@@ -70,17 +115,47 @@ type NTPActivity struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Precision: The NTP precision quantifies a clock's accuracy and stability in log2 seconds, as defined in RFC-5905.
 	Precision *int32 `json:"precision,omitempty" parquet:"precision,optional"`
+
+	// Proxy Connection Info: The connection information from the proxy server to the remote server.
+	ProxyConnectionInfo *NetworkConnectionInformation `json:"proxy_connection_info,omitempty" parquet:"proxy_connection_info,optional"`
+
+	// Proxy Endpoint: The proxy (server) in a network connection.
+	ProxyEndpoint *NetworkProxyEndpoint `json:"proxy_endpoint,omitempty" parquet:"proxy_endpoint,optional"`
+
+	// Proxy HTTP Request: The HTTP Request from the proxy server to the remote server.
+	ProxyHttpRequest *HTTPRequest `json:"proxy_http_request,omitempty" parquet:"proxy_http_request,optional"`
+
+	// Proxy HTTP Response: The HTTP Response from the remote server to the proxy server.
+	ProxyHttpResponse *HTTPResponse `json:"proxy_http_response,omitempty" parquet:"proxy_http_response,optional"`
+
+	// Proxy TLS: The TLS protocol negotiated between the proxy server and the remote server.
+	ProxyTls *TransportLayerSecurityTLS `json:"proxy_tls,omitempty" parquet:"proxy_tls,optional"`
+
+	// Proxy Traffic: The network traffic refers to the amount of data moving across a network, from proxy to remote server at a given point of time.
+	ProxyTraffic *NetworkTraffic `json:"proxy_traffic,omitempty" parquet:"proxy_traffic,optional"`
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
 
 	// Raw Data Size: The size of the raw data which was transformed into an OCSF event, in bytes.
 	RawDataSize *int64 `json:"raw_data_size,omitempty" parquet:"raw_data_size,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the <code>severity_id</code> value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -161,30 +236,55 @@ func (v *NTPActivity) ValidateObservables() error {
 }
 
 var NTPActivityFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
 	{Name: "app_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKATLASStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "connection_info", Type: NetworkConnectionInformationStruct, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "delay", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
 	{Name: "dispersion", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "dst_endpoint", Type: NetworkEndpointStruct, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
 	{Name: "ja4_fingerprint_list", Type: arrow.ListOf(JA4FingerprintStruct), Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
+	{Name: "malware_scan_info", Type: MalwareScanInfoStruct, Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "precision", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "proxy_connection_info", Type: NetworkConnectionInformationStruct, Nullable: true},
+	{Name: "proxy_endpoint", Type: NetworkProxyEndpointStruct, Nullable: true},
+	{Name: "proxy_http_request", Type: HTTPRequestStruct, Nullable: true},
+	{Name: "proxy_http_response", Type: HTTPResponseStruct, Nullable: true},
+	{Name: "proxy_tls", Type: TransportLayerSecurityTLSStruct, Nullable: true},
+	{Name: "proxy_traffic", Type: NetworkTrafficStruct, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "raw_data_size", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "src_endpoint", Type: NetworkEndpointStruct, Nullable: true},

--- a/ocsf/v1_5_0/osint_inventory_info.go
+++ b/ocsf/v1_5_0/osint_inventory_info.go
@@ -10,11 +10,29 @@ import (
 
 type OSINTInventoryInfo struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
+
+	// Actor: The actor describes the process that was the source of the inventory activity. In the case of OSINT inventory data, that could be a particular process or script that is run to scrape the OSINT or threat intelligence data. For example, it could be a Python process that runs to pull data from a MISP or Shodan API.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® and ATLAS™ Details: An array of MITRE ATT&CK® objects describing identified tactics, techniques & sub-techniques. The objects are compatible with MITRE ATLAS™ tactics, techniques & sub-techniques.
+	Attacks []MITREATTCKATLAS `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Discovery</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -28,11 +46,26 @@ type OSINTInventoryInfo struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
+
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -43,6 +76,18 @@ type OSINTInventoryInfo struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
+	// Malware Scan Info: Describes details about the scan job that identified malware on the target system.
+	MalwareScanInfo *MalwareScanInfo `json:"malware_scan_info,omitempty" parquet:"malware_scan_info,optional"`
+
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
 
@@ -52,14 +97,26 @@ type OSINTInventoryInfo struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT that is being discovered by an inventory process.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
 
 	// Raw Data Size: The size of the raw data which was transformed into an OCSF event, in bytes.
 	RawDataSize *int64 `json:"raw_data_size,omitempty" parquet:"raw_data_size,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the <code>severity_id</code> value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -122,23 +179,42 @@ func (v *OSINTInventoryInfo) ValidateObservables() error {
 }
 
 var OSINTInventoryInfoFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKATLASStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
+	{Name: "malware_scan_info", Type: MalwareScanInfoStruct, Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "raw_data_size", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "start_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},

--- a/ocsf/v1_5_0/patch_state.go
+++ b/ocsf/v1_5_0/patch_state.go
@@ -10,11 +10,29 @@ import (
 
 type OperatingSystemPatchState struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
+
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® and ATLAS™ Details: An array of MITRE ATT&CK® objects describing identified tactics, techniques & sub-techniques. The objects are compatible with MITRE ATLAS™ tactics, techniques & sub-techniques.
+	Attacks []MITREATTCKATLAS `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Discovery</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -28,14 +46,26 @@ type OperatingSystemPatchState struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
 
 	// Device: An addressable device, computer system or host.
 	Device Device `json:"device" parquet:"device"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -46,8 +76,20 @@ type OperatingSystemPatchState struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
 	// Knowledgebase Articles: A list of KB articles or patches related to an endpoint. A KB Article contains metadata that describes the patch or an update.
 	KbArticleList []KBArticle `json:"kb_article_list,omitempty" parquet:"kb_article_list,list,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
+	// Malware Scan Info: Describes details about the scan job that identified malware on the target system.
+	MalwareScanInfo *MalwareScanInfo `json:"malware_scan_info,omitempty" parquet:"malware_scan_info,optional"`
 
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
@@ -58,14 +100,26 @@ type OperatingSystemPatchState struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
 
 	// Raw Data Size: The size of the raw data which was transformed into an OCSF event, in bytes.
 	RawDataSize *int64 `json:"raw_data_size,omitempty" parquet:"raw_data_size,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the <code>severity_id</code> value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -128,25 +182,43 @@ func (v *OperatingSystemPatchState) ValidateObservables() error {
 }
 
 var OperatingSystemPatchStateFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKATLASStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "device", Type: DeviceStruct, Nullable: false},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
 	{Name: "kb_article_list", Type: arrow.ListOf(KBArticleStruct), Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
+	{Name: "malware_scan_info", Type: MalwareScanInfoStruct, Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "raw_data_size", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "start_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},

--- a/ocsf/v1_5_0/peripheral_device_query.go
+++ b/ocsf/v1_5_0/peripheral_device_query.go
@@ -10,11 +10,29 @@ import (
 
 type PeripheralDeviceQuery struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
+
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® and ATLAS™ Details: An array of MITRE ATT&CK® objects describing identified tactics, techniques & sub-techniques. The objects are compatible with MITRE ATLAS™ tactics, techniques & sub-techniques.
+	Attacks []MITREATTCKATLAS `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Discovery</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -28,11 +46,26 @@ type PeripheralDeviceQuery struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
+
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -43,6 +76,18 @@ type PeripheralDeviceQuery struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
+	// Malware Scan Info: Describes details about the scan job that identified malware on the target system.
+	MalwareScanInfo *MalwareScanInfo `json:"malware_scan_info,omitempty" parquet:"malware_scan_info,optional"`
+
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
 
@@ -52,11 +97,11 @@ type PeripheralDeviceQuery struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
-
 	// Peripheral Device: The peripheral device that triggered the event.
 	PeripheralDevice PeripheralDevice `json:"peripheral_device" parquet:"peripheral_device"`
+
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Query Info: The search details associated with the query request.
 	QueryInfo *QueryInformation `json:"query_info,omitempty" parquet:"query_info,optional"`
@@ -72,6 +117,18 @@ type PeripheralDeviceQuery struct {
 
 	// Raw Data Size: The size of the raw data which was transformed into an OCSF event, in bytes.
 	RawDataSize *int64 `json:"raw_data_size,omitempty" parquet:"raw_data_size,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the <code>severity_id</code> value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -134,27 +191,46 @@ func (v *PeripheralDeviceQuery) ValidateObservables() error {
 }
 
 var PeripheralDeviceQueryFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKATLASStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
+	{Name: "malware_scan_info", Type: MalwareScanInfoStruct, Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
 	{Name: "peripheral_device", Type: PeripheralDeviceStruct, Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "query_info", Type: QueryInformationStruct, Nullable: true},
 	{Name: "query_result", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "query_result_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "raw_data_size", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "start_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},

--- a/ocsf/v1_5_0/prefetch_query.go
+++ b/ocsf/v1_5_0/prefetch_query.go
@@ -10,11 +10,29 @@ import (
 
 type PrefetchQuery struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
+
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® and ATLAS™ Details: An array of MITRE ATT&CK® objects describing identified tactics, techniques & sub-techniques. The objects are compatible with MITRE ATLAS™ tactics, techniques & sub-techniques.
+	Attacks []MITREATTCKATLAS `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Discovery</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -28,11 +46,26 @@ type PrefetchQuery struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
+
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -43,8 +76,20 @@ type PrefetchQuery struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
 	// Last Run: The prefetch file last run time.
 	LastRunTime int64 `json:"last_run_time,omitempty" parquet:"last_run_time,timestamp_millis,timestamp(millisecond),optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
+	// Malware Scan Info: Describes details about the scan job that identified malware on the target system.
+	MalwareScanInfo *MalwareScanInfo `json:"malware_scan_info,omitempty" parquet:"malware_scan_info,optional"`
 
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
@@ -58,8 +103,8 @@ type PrefetchQuery struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Query Info: The search details associated with the query request.
 	QueryInfo *QueryInformation `json:"query_info,omitempty" parquet:"query_info,optional"`
@@ -75,6 +120,18 @@ type PrefetchQuery struct {
 
 	// Raw Data Size: The size of the raw data which was transformed into an OCSF event, in bytes.
 	RawDataSize *int64 `json:"raw_data_size,omitempty" parquet:"raw_data_size,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Run Count: The prefetch file run count.
 	RunCount *int32 `json:"run_count,omitempty" parquet:"run_count,optional"`
@@ -140,28 +197,47 @@ func (v *PrefetchQuery) ValidateObservables() error {
 }
 
 var PrefetchQueryFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKATLASStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
 	{Name: "last_run_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
+	{Name: "malware_scan_info", Type: MalwareScanInfoStruct, Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "name", Type: arrow.BinaryTypes.String, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "query_info", Type: QueryInformationStruct, Nullable: true},
 	{Name: "query_result", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "query_result_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "raw_data_size", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "run_count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},

--- a/ocsf/v1_5_0/process_activity.go
+++ b/ocsf/v1_5_0/process_activity.go
@@ -10,6 +10,12 @@ import (
 
 type ProcessActivity struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
@@ -21,6 +27,15 @@ type ProcessActivity struct {
 
 	// Actual Permissions: The permissions that were granted to the process in a platform-native format.
 	ActualPermissions *int32 `json:"actual_permissions,omitempty" parquet:"actual_permissions,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® and ATLAS™ Details: An array of MITRE ATT&CK® objects describing identified tactics, techniques & sub-techniques. The objects are compatible with MITRE ATLAS™ tactics, techniques & sub-techniques.
+	Attacks []MITREATTCKATLAS `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>System Activity</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -34,14 +49,26 @@ type ProcessActivity struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
 
 	// Device: An addressable device, computer system or host.
 	Device Device `json:"device" parquet:"device"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -55,11 +82,23 @@ type ProcessActivity struct {
 	// Exit Code: The exit code reported by a process when it terminates. The convention is that zero indicates success and any non-zero exit code indicates that some error occurred.
 	ExitCode *int32 `json:"exit_code,omitempty" parquet:"exit_code,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
 	// Injection Type: The process injection method, normalized to the caption of the injection_type_id value. In the case of 'Other', it is defined by the event source.
 	InjectionType *string `json:"injection_type,omitempty" parquet:"injection_type,optional"`
 
 	// Injection Type ID: The normalized identifier of the process injection method.
 	InjectionTypeId *int32 `json:"injection_type_id,omitempty" parquet:"injection_type_id,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
+	// Malware Scan Info: Describes details about the scan job that identified malware on the target system.
+	MalwareScanInfo *MalwareScanInfo `json:"malware_scan_info,omitempty" parquet:"malware_scan_info,optional"`
 
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
@@ -73,8 +112,8 @@ type ProcessActivity struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Process: The process that was launched, injected into, opened, or terminated.
 	Process Process `json:"process" parquet:"process"`
@@ -87,6 +126,18 @@ type ProcessActivity struct {
 
 	// Requested Permissions: The permissions mask that was requested by the process.
 	RequestedPermissions *int32 `json:"requested_permissions,omitempty" parquet:"requested_permissions,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the <code>severity_id</code> value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -149,32 +200,49 @@ func (v *ProcessActivity) ValidateObservables() error {
 }
 
 var ProcessActivityFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "actor", Type: ActorStruct, Nullable: false},
 	{Name: "actual_permissions", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKATLASStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "device", Type: DeviceStruct, Nullable: false},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
 	{Name: "exit_code", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
 	{Name: "injection_type", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "injection_type_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
+	{Name: "malware_scan_info", Type: MalwareScanInfoStruct, Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "module", Type: ModuleStruct, Nullable: true},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "process", Type: ProcessStruct, Nullable: false},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "raw_data_size", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "requested_permissions", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "start_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},

--- a/ocsf/v1_5_0/process_query.go
+++ b/ocsf/v1_5_0/process_query.go
@@ -10,11 +10,29 @@ import (
 
 type ProcessQuery struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
+
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® and ATLAS™ Details: An array of MITRE ATT&CK® objects describing identified tactics, techniques & sub-techniques. The objects are compatible with MITRE ATLAS™ tactics, techniques & sub-techniques.
+	Attacks []MITREATTCKATLAS `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Discovery</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -28,11 +46,26 @@ type ProcessQuery struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
+
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -43,6 +76,18 @@ type ProcessQuery struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
+	// Malware Scan Info: Describes details about the scan job that identified malware on the target system.
+	MalwareScanInfo *MalwareScanInfo `json:"malware_scan_info,omitempty" parquet:"malware_scan_info,optional"`
+
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
 
@@ -52,8 +97,8 @@ type ProcessQuery struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Process: The process object.
 	Process Process `json:"process" parquet:"process"`
@@ -72,6 +117,18 @@ type ProcessQuery struct {
 
 	// Raw Data Size: The size of the raw data which was transformed into an OCSF event, in bytes.
 	RawDataSize *int64 `json:"raw_data_size,omitempty" parquet:"raw_data_size,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the <code>severity_id</code> value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -134,27 +191,46 @@ func (v *ProcessQuery) ValidateObservables() error {
 }
 
 var ProcessQueryFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKATLASStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
+	{Name: "malware_scan_info", Type: MalwareScanInfoStruct, Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "process", Type: ProcessStruct, Nullable: false},
 	{Name: "query_info", Type: QueryInformationStruct, Nullable: true},
 	{Name: "query_result", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "query_result_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "raw_data_size", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "start_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},

--- a/ocsf/v1_5_0/process_remediation_activity.go
+++ b/ocsf/v1_5_0/process_remediation_activity.go
@@ -10,11 +10,29 @@ import (
 
 type ProcessRemediationActivity struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: Matches the MITRE D3FEND™ Tactic. Note: the Model and Detect Tactics are not supported as remediations by the OCSF Remediation event class.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
+
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® and ATLAS™ Details: An array of MITRE ATT&CK® objects describing identified tactics, techniques & sub-techniques. The objects are compatible with MITRE ATLAS™ tactics, techniques & sub-techniques.
+	Attacks []MITREATTCKATLAS `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Remediation</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -28,17 +46,32 @@ type ProcessRemediationActivity struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
-
 	// Command UID: The unique identifier of the remediation command that pertains to this event.
 	CommandUid string `json:"command_uid" parquet:"command_uid"`
+
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
 
 	// Countermeasures: The MITRE D3FEND™ Matrix Countermeasures associated with a remediation.
 	Countermeasures []MITRED3FEND `json:"countermeasures,omitempty" parquet:"countermeasures,list,optional"`
+
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -49,6 +82,18 @@ type ProcessRemediationActivity struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
+	// Malware Scan Info: Describes details about the scan job that identified malware on the target system.
+	MalwareScanInfo *MalwareScanInfo `json:"malware_scan_info,omitempty" parquet:"malware_scan_info,optional"`
+
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
 
@@ -58,8 +103,8 @@ type ProcessRemediationActivity struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Process: The process that pertains to the remediation event.
 	Process Process `json:"process" parquet:"process"`
@@ -72,6 +117,18 @@ type ProcessRemediationActivity struct {
 
 	// Remediation Guidance: Describes the recommended remediation steps to address identified issue(s).
 	Remediation *Remediation `json:"remediation,omitempty" parquet:"remediation,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Scan: The remediation scan that pertains to this event.
 	Scan *Scan `json:"scan,omitempty" parquet:"scan,optional"`
@@ -137,27 +194,46 @@ func (v *ProcessRemediationActivity) ValidateObservables() error {
 }
 
 var ProcessRemediationActivityFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKATLASStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
 	{Name: "command_uid", Type: arrow.BinaryTypes.String, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "countermeasures", Type: arrow.ListOf(MITRED3FENDStruct), Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
+	{Name: "malware_scan_info", Type: MalwareScanInfoStruct, Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "process", Type: ProcessStruct, Nullable: false},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "raw_data_size", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "remediation", Type: RemediationStruct, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "scan", Type: ScanStruct, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},

--- a/ocsf/v1_5_0/rdp_activity.go
+++ b/ocsf/v1_5_0/rdp_activity.go
@@ -10,14 +10,32 @@ import (
 
 type RDPActivity struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
 
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
 	// Application Name: The name of the application associated with the event or object.
 	AppName *string `json:"app_name,omitempty" parquet:"app_name,optional"`
+
+	// MITRE ATT&CK® and ATLAS™ Details: An array of MITRE ATT&CK® objects describing identified tactics, techniques & sub-techniques. The objects are compatible with MITRE ATLAS™ tactics, techniques & sub-techniques.
+	Attacks []MITREATTCKATLAS `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Capabilities: A list of RDP capabilities.
 	Capabilities []string `json:"capabilities,omitempty" parquet:"capabilities,list,optional"`
@@ -37,14 +55,29 @@ type RDPActivity struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Connection Info: The network connection information.
 	ConnectionInfo *NetworkConnectionInformation `json:"connection_info,omitempty" parquet:"connection_info,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
+
+	// Device: The device instigating the RDP connection.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Destination Endpoint: The responder (server) in a network connection.
 	DstEndpoint *NetworkEndpoint `json:"dst_endpoint,omitempty" parquet:"dst_endpoint,optional"`
@@ -61,14 +94,26 @@ type RDPActivity struct {
 	// File: The file that is the target of the RDP activity.
 	File *File `json:"file,omitempty" parquet:"file,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
 	// Identifier Cookie: The client identifier cookie during client/server exchange.
 	IdentifierCookie *string `json:"identifier_cookie,omitempty" parquet:"identifier_cookie,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
 
 	// JA4+ Fingerprints: A list of the JA4+ network fingerprints.
 	Ja4FingerprintList []JA4Fingerprint `json:"ja4_fingerprint_list,omitempty" parquet:"ja4_fingerprint_list,list,optional"`
 
 	// Keyboard Information: The keyboard detailed information.
 	KeyboardInfo *KeyboardInformation `json:"keyboard_info,omitempty" parquet:"keyboard_info,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
+	// Malware Scan Info: Describes details about the scan job that identified malware on the target system.
+	MalwareScanInfo *MalwareScanInfo `json:"malware_scan_info,omitempty" parquet:"malware_scan_info,optional"`
 
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
@@ -79,11 +124,29 @@ type RDPActivity struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// RDP Version: The Remote Desktop Protocol version.
 	ProtocolVer *string `json:"protocol_ver,omitempty" parquet:"protocol_ver,optional"`
+
+	// Proxy Connection Info: The connection information from the proxy server to the remote server.
+	ProxyConnectionInfo *NetworkConnectionInformation `json:"proxy_connection_info,omitempty" parquet:"proxy_connection_info,optional"`
+
+	// Proxy Endpoint: The proxy (server) in a network connection.
+	ProxyEndpoint *NetworkProxyEndpoint `json:"proxy_endpoint,omitempty" parquet:"proxy_endpoint,optional"`
+
+	// Proxy HTTP Request: The HTTP Request from the proxy server to the remote server.
+	ProxyHttpRequest *HTTPRequest `json:"proxy_http_request,omitempty" parquet:"proxy_http_request,optional"`
+
+	// Proxy HTTP Response: The HTTP Response from the remote server to the proxy server.
+	ProxyHttpResponse *HTTPResponse `json:"proxy_http_response,omitempty" parquet:"proxy_http_response,optional"`
+
+	// Proxy TLS: The TLS protocol negotiated between the proxy server and the remote server.
+	ProxyTls *TransportLayerSecurityTLS `json:"proxy_tls,omitempty" parquet:"proxy_tls,optional"`
+
+	// Proxy Traffic: The network traffic refers to the amount of data moving across a network, from proxy to remote server at a given point of time.
+	ProxyTraffic *NetworkTraffic `json:"proxy_traffic,omitempty" parquet:"proxy_traffic,optional"`
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
@@ -99,6 +162,18 @@ type RDPActivity struct {
 
 	// API Response Details: The server response in an RDP network connection.
 	Response *ResponseElements `json:"response,omitempty" parquet:"response,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the <code>severity_id</code> value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -170,36 +245,61 @@ func (v *RDPActivity) ValidateObservables() error {
 }
 
 var RDPActivityFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
 	{Name: "app_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKATLASStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "capabilities", Type: arrow.ListOf(arrow.BinaryTypes.String), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "certificate_chain", Type: arrow.ListOf(arrow.BinaryTypes.String), Nullable: true},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "connection_info", Type: NetworkConnectionInformationStruct, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "dst_endpoint", Type: NetworkEndpointStruct, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
 	{Name: "file", Type: FileStruct, Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
 	{Name: "identifier_cookie", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
 	{Name: "ja4_fingerprint_list", Type: arrow.ListOf(JA4FingerprintStruct), Nullable: true},
 	{Name: "keyboard_info", Type: KeyboardInformationStruct, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
+	{Name: "malware_scan_info", Type: MalwareScanInfoStruct, Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "protocol_ver", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "proxy_connection_info", Type: NetworkConnectionInformationStruct, Nullable: true},
+	{Name: "proxy_endpoint", Type: NetworkProxyEndpointStruct, Nullable: true},
+	{Name: "proxy_http_request", Type: HTTPRequestStruct, Nullable: true},
+	{Name: "proxy_http_response", Type: HTTPResponseStruct, Nullable: true},
+	{Name: "proxy_tls", Type: TransportLayerSecurityTLSStruct, Nullable: true},
+	{Name: "proxy_traffic", Type: NetworkTrafficStruct, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "raw_data_size", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "remote_display", Type: DisplayStruct, Nullable: true},
 	{Name: "request", Type: RequestElementsStruct, Nullable: true},
 	{Name: "response", Type: ResponseElementsStruct, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "src_endpoint", Type: NetworkEndpointStruct, Nullable: true},

--- a/ocsf/v1_5_0/registry_key_activity.go
+++ b/ocsf/v1_5_0/registry_key_activity.go
@@ -13,6 +13,12 @@ type RegistryKeyActivity struct {
 	// Access Mask: The access mask in a platform-native format.
 	AccessMask *int32 `json:"access_mask,omitempty" parquet:"access_mask,optional"`
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
@@ -21,6 +27,15 @@ type RegistryKeyActivity struct {
 
 	// Actor: The actor that performed the activity on the <code>reg_key</code> object.
 	Actor Actor `json:"actor" parquet:"actor"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® and ATLAS™ Details: An array of MITRE ATT&CK® objects describing identified tactics, techniques & sub-techniques. The objects are compatible with MITRE ATLAS™ tactics, techniques & sub-techniques.
+	Attacks []MITREATTCKATLAS `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>System Activity</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -34,8 +49,14 @@ type RegistryKeyActivity struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
@@ -46,6 +67,12 @@ type RegistryKeyActivity struct {
 	// Device: An addressable device, computer system or host.
 	Device Device `json:"device" parquet:"device"`
 
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
+
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
 
@@ -54,6 +81,18 @@ type RegistryKeyActivity struct {
 
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
+
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
+	// Malware Scan Info: Describes details about the scan job that identified malware on the target system.
+	MalwareScanInfo *MalwareScanInfo `json:"malware_scan_info,omitempty" parquet:"malware_scan_info,optional"`
 
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
@@ -67,8 +106,8 @@ type RegistryKeyActivity struct {
 	// Open Mask: The Windows options needed to open a registry key.
 	OpenMask *int32 `json:"open_mask,omitempty" parquet:"open_mask,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Previous Registry Key: The registry key before the mutation
 	PrevRegKey *RegistryKey `json:"prev_reg_key,omitempty" parquet:"prev_reg_key,optional"`
@@ -81,6 +120,18 @@ type RegistryKeyActivity struct {
 
 	// Registry Key: The registry key.
 	RegKey RegistryKey `json:"reg_key" parquet:"reg_key"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the <code>severity_id</code> value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -144,29 +195,46 @@ func (v *RegistryKeyActivity) ValidateObservables() error {
 
 var RegistryKeyActivityFields = []arrow.Field{
 	{Name: "access_mask", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "actor", Type: ActorStruct, Nullable: false},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKATLASStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "create_mask", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "device", Type: DeviceStruct, Nullable: false},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
+	{Name: "malware_scan_info", Type: MalwareScanInfoStruct, Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
 	{Name: "open_mask", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "prev_reg_key", Type: RegistryKeyStruct, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "raw_data_size", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "reg_key", Type: RegistryKeyStruct, Nullable: false},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "start_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},

--- a/ocsf/v1_5_0/registry_key_query.go
+++ b/ocsf/v1_5_0/registry_key_query.go
@@ -10,11 +10,29 @@ import (
 
 type RegistryKeyQuery struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
+
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® and ATLAS™ Details: An array of MITRE ATT&CK® objects describing identified tactics, techniques & sub-techniques. The objects are compatible with MITRE ATLAS™ tactics, techniques & sub-techniques.
+	Attacks []MITREATTCKATLAS `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Discovery</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -28,11 +46,26 @@ type RegistryKeyQuery struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
+
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -43,6 +76,18 @@ type RegistryKeyQuery struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
+	// Malware Scan Info: Describes details about the scan job that identified malware on the target system.
+	MalwareScanInfo *MalwareScanInfo `json:"malware_scan_info,omitempty" parquet:"malware_scan_info,optional"`
+
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
 
@@ -52,8 +97,8 @@ type RegistryKeyQuery struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Query Info: The search details associated with the query request.
 	QueryInfo *QueryInformation `json:"query_info,omitempty" parquet:"query_info,optional"`
@@ -72,6 +117,18 @@ type RegistryKeyQuery struct {
 
 	// Registry Key: The registry key that pertains to the event.
 	RegKey RegistryKey `json:"reg_key" parquet:"reg_key"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the <code>severity_id</code> value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -134,27 +191,46 @@ func (v *RegistryKeyQuery) ValidateObservables() error {
 }
 
 var RegistryKeyQueryFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKATLASStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
+	{Name: "malware_scan_info", Type: MalwareScanInfoStruct, Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "query_info", Type: QueryInformationStruct, Nullable: true},
 	{Name: "query_result", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "query_result_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "raw_data_size", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "reg_key", Type: RegistryKeyStruct, Nullable: false},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "start_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},

--- a/ocsf/v1_5_0/registry_value_activity.go
+++ b/ocsf/v1_5_0/registry_value_activity.go
@@ -10,6 +10,12 @@ import (
 
 type RegistryValueActivity struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
@@ -18,6 +24,15 @@ type RegistryValueActivity struct {
 
 	// Actor: The actor that performed the activity on the <code>reg_value</code> object.
 	Actor Actor `json:"actor" parquet:"actor"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® and ATLAS™ Details: An array of MITRE ATT&CK® objects describing identified tactics, techniques & sub-techniques. The objects are compatible with MITRE ATLAS™ tactics, techniques & sub-techniques.
+	Attacks []MITREATTCKATLAS `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>System Activity</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -31,14 +46,26 @@ type RegistryValueActivity struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
 
 	// Device: An addressable device, computer system or host.
 	Device Device `json:"device" parquet:"device"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -49,6 +76,18 @@ type RegistryValueActivity struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
+	// Malware Scan Info: Describes details about the scan job that identified malware on the target system.
+	MalwareScanInfo *MalwareScanInfo `json:"malware_scan_info,omitempty" parquet:"malware_scan_info,optional"`
+
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
 
@@ -58,8 +97,8 @@ type RegistryValueActivity struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Previous Registry Value: The registry value before the mutation
 	PrevRegValue *RegistryValue `json:"prev_reg_value,omitempty" parquet:"prev_reg_value,optional"`
@@ -72,6 +111,18 @@ type RegistryValueActivity struct {
 
 	// Registry Value: The registry value.
 	RegValue RegistryValue `json:"reg_value" parquet:"reg_value"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the <code>severity_id</code> value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -134,27 +185,44 @@ func (v *RegistryValueActivity) ValidateObservables() error {
 }
 
 var RegistryValueActivityFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "actor", Type: ActorStruct, Nullable: false},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKATLASStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "device", Type: DeviceStruct, Nullable: false},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
+	{Name: "malware_scan_info", Type: MalwareScanInfoStruct, Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "prev_reg_value", Type: RegistryValueStruct, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "raw_data_size", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "reg_value", Type: RegistryValueStruct, Nullable: false},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "start_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},

--- a/ocsf/v1_5_0/registry_value_query.go
+++ b/ocsf/v1_5_0/registry_value_query.go
@@ -10,11 +10,29 @@ import (
 
 type RegistryValueQuery struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
+
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® and ATLAS™ Details: An array of MITRE ATT&CK® objects describing identified tactics, techniques & sub-techniques. The objects are compatible with MITRE ATLAS™ tactics, techniques & sub-techniques.
+	Attacks []MITREATTCKATLAS `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Discovery</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -28,11 +46,26 @@ type RegistryValueQuery struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
+
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -43,6 +76,18 @@ type RegistryValueQuery struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
+	// Malware Scan Info: Describes details about the scan job that identified malware on the target system.
+	MalwareScanInfo *MalwareScanInfo `json:"malware_scan_info,omitempty" parquet:"malware_scan_info,optional"`
+
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
 
@@ -52,8 +97,8 @@ type RegistryValueQuery struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Query Info: The search details associated with the query request.
 	QueryInfo *QueryInformation `json:"query_info,omitempty" parquet:"query_info,optional"`
@@ -72,6 +117,18 @@ type RegistryValueQuery struct {
 
 	// Registry Value: The registry value that pertains to the event.
 	RegValue RegistryValue `json:"reg_value" parquet:"reg_value"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the <code>severity_id</code> value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -134,27 +191,46 @@ func (v *RegistryValueQuery) ValidateObservables() error {
 }
 
 var RegistryValueQueryFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKATLASStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
+	{Name: "malware_scan_info", Type: MalwareScanInfoStruct, Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "query_info", Type: QueryInformationStruct, Nullable: true},
 	{Name: "query_result", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "query_result_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "raw_data_size", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "reg_value", Type: RegistryValueStruct, Nullable: false},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "start_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},

--- a/ocsf/v1_5_0/remediation_activity.go
+++ b/ocsf/v1_5_0/remediation_activity.go
@@ -10,11 +10,29 @@ import (
 
 type RemediationActivity struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: Matches the MITRE D3FEND™ Tactic. Note: the Model and Detect Tactics are not supported as remediations by the OCSF Remediation event class.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
+
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® and ATLAS™ Details: An array of MITRE ATT&CK® objects describing identified tactics, techniques & sub-techniques. The objects are compatible with MITRE ATLAS™ tactics, techniques & sub-techniques.
+	Attacks []MITREATTCKATLAS `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Remediation</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -28,17 +46,32 @@ type RemediationActivity struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
-
 	// Command UID: The unique identifier of the remediation command that pertains to this event.
 	CommandUid string `json:"command_uid" parquet:"command_uid"`
+
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
 
 	// Countermeasures: The MITRE D3FEND™ Matrix Countermeasures associated with a remediation.
 	Countermeasures []MITRED3FEND `json:"countermeasures,omitempty" parquet:"countermeasures,list,optional"`
+
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -49,6 +82,18 @@ type RemediationActivity struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
+	// Malware Scan Info: Describes details about the scan job that identified malware on the target system.
+	MalwareScanInfo *MalwareScanInfo `json:"malware_scan_info,omitempty" parquet:"malware_scan_info,optional"`
+
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
 
@@ -58,8 +103,8 @@ type RemediationActivity struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
@@ -69,6 +114,18 @@ type RemediationActivity struct {
 
 	// Remediation Guidance: Describes the recommended remediation steps to address identified issue(s).
 	Remediation *Remediation `json:"remediation,omitempty" parquet:"remediation,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Scan: The remediation scan that pertains to this event.
 	Scan *Scan `json:"scan,omitempty" parquet:"scan,optional"`
@@ -134,26 +191,45 @@ func (v *RemediationActivity) ValidateObservables() error {
 }
 
 var RemediationActivityFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKATLASStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
 	{Name: "command_uid", Type: arrow.BinaryTypes.String, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "countermeasures", Type: arrow.ListOf(MITRED3FENDStruct), Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
+	{Name: "malware_scan_info", Type: MalwareScanInfoStruct, Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "raw_data_size", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "remediation", Type: RemediationStruct, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "scan", Type: ScanStruct, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},

--- a/ocsf/v1_5_0/scan_activity.go
+++ b/ocsf/v1_5_0/scan_activity.go
@@ -10,11 +10,29 @@ import (
 
 type ScanActivity struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
+
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® and ATLAS™ Details: An array of MITRE ATT&CK® objects describing identified tactics, techniques & sub-techniques. The objects are compatible with MITRE ATLAS™ tactics, techniques & sub-techniques.
+	Attacks []MITREATTCKATLAS `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Application Activity</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -28,14 +46,29 @@ type ScanActivity struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
-
 	// Command UID: The command identifier that is associated with this scan event.  This ID uniquely identifies the proactive scan command, e.g., if remotely initiated.
 	CommandUid *string `json:"command_uid,omitempty" parquet:"command_uid,optional"`
 
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
+
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
+
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The duration of the scan
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -45,6 +78,18 @@ type ScanActivity struct {
 
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
+
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
+	// Malware Scan Info: Describes details about the scan job that identified malware on the target system.
+	MalwareScanInfo *MalwareScanInfo `json:"malware_scan_info,omitempty" parquet:"malware_scan_info,optional"`
 
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
@@ -82,14 +127,26 @@ type ScanActivity struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy associated with this Scan event; required if the scan was initiated by a policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
 
 	// Raw Data Size: The size of the raw data which was transformed into an OCSF event, in bytes.
 	RawDataSize *int64 `json:"raw_data_size,omitempty" parquet:"raw_data_size,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Scan: The Scan object describes characteristics of the scan job.
 	Scan Scan `json:"scan" parquet:"scan"`
@@ -161,18 +218,33 @@ func (v *ScanActivity) ValidateObservables() error {
 }
 
 var ScanActivityFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKATLASStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
 	{Name: "command_uid", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
+	{Name: "malware_scan_info", Type: MalwareScanInfoStruct, Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "num_detections", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
@@ -185,9 +257,13 @@ var ScanActivityFields = []arrow.Field{
 	{Name: "num_skipped_items", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "num_trusted_items", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "raw_data_size", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "scan", Type: ScanStruct, Nullable: false},
 	{Name: "schedule_uid", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},

--- a/ocsf/v1_5_0/scheduled_job_activity.go
+++ b/ocsf/v1_5_0/scheduled_job_activity.go
@@ -10,11 +10,29 @@ import (
 
 type ScheduledJobActivity struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
+
+	// Actor: The actor that performed the activity on the <code>job</code> object.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® and ATLAS™ Details: An array of MITRE ATT&CK® objects describing identified tactics, techniques & sub-techniques. The objects are compatible with MITRE ATLAS™ tactics, techniques & sub-techniques.
+	Attacks []MITREATTCKATLAS `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>System Activity</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -28,14 +46,26 @@ type ScheduledJobActivity struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
 
 	// Device: An addressable device, computer system or host.
 	Device Device `json:"device" parquet:"device"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -46,8 +76,20 @@ type ScheduledJobActivity struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
 	// Job: The job object that pertains to the event.
 	Job Job `json:"job" parquet:"job"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
+	// Malware Scan Info: Describes details about the scan job that identified malware on the target system.
+	MalwareScanInfo *MalwareScanInfo `json:"malware_scan_info,omitempty" parquet:"malware_scan_info,optional"`
 
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
@@ -58,14 +100,26 @@ type ScheduledJobActivity struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
 
 	// Raw Data Size: The size of the raw data which was transformed into an OCSF event, in bytes.
 	RawDataSize *int64 `json:"raw_data_size,omitempty" parquet:"raw_data_size,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the <code>severity_id</code> value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -128,25 +182,43 @@ func (v *ScheduledJobActivity) ValidateObservables() error {
 }
 
 var ScheduledJobActivityFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKATLASStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "device", Type: DeviceStruct, Nullable: false},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
 	{Name: "job", Type: JobStruct, Nullable: false},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
+	{Name: "malware_scan_info", Type: MalwareScanInfoStruct, Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "raw_data_size", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "start_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},

--- a/ocsf/v1_5_0/script_activity.go
+++ b/ocsf/v1_5_0/script_activity.go
@@ -10,6 +10,12 @@ import (
 
 type ScriptActivity struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
@@ -18,6 +24,15 @@ type ScriptActivity struct {
 
 	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
 	Actor Actor `json:"actor" parquet:"actor"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® and ATLAS™ Details: An array of MITRE ATT&CK® objects describing identified tactics, techniques & sub-techniques. The objects are compatible with MITRE ATLAS™ tactics, techniques & sub-techniques.
+	Attacks []MITREATTCKATLAS `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>System Activity</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -31,14 +46,26 @@ type ScriptActivity struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
 
 	// Device: An addressable device, computer system or host.
 	Device Device `json:"device" parquet:"device"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -49,6 +76,18 @@ type ScriptActivity struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
+	// Malware Scan Info: Describes details about the scan job that identified malware on the target system.
+	MalwareScanInfo *MalwareScanInfo `json:"malware_scan_info,omitempty" parquet:"malware_scan_info,optional"`
+
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
 
@@ -58,14 +97,26 @@ type ScriptActivity struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
 
 	// Raw Data Size: The size of the raw data which was transformed into an OCSF event, in bytes.
 	RawDataSize *int64 `json:"raw_data_size,omitempty" parquet:"raw_data_size,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Script: The script that was the target of the activity.
 	Script Script `json:"script" parquet:"script"`
@@ -131,25 +182,42 @@ func (v *ScriptActivity) ValidateObservables() error {
 }
 
 var ScriptActivityFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "actor", Type: ActorStruct, Nullable: false},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKATLASStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "device", Type: DeviceStruct, Nullable: false},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
+	{Name: "malware_scan_info", Type: MalwareScanInfoStruct, Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "raw_data_size", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "script", Type: ScriptStruct, Nullable: false},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},

--- a/ocsf/v1_5_0/security_finding.go
+++ b/ocsf/v1_5_0/security_finding.go
@@ -10,14 +10,32 @@ import (
 
 type SecurityFinding struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
 
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
 	// Analytic: The analytic technique used to analyze and derive insights from the data or information that led to the finding or conclusion.
 	Analytic *Analytic `json:"analytic,omitempty" parquet:"analytic,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® and ATLAS™ Details: An array of <a target='_blank' href='https://attack.mitre.org'>MITRE ATT&CK®</a> objects describing the tactics, techniques & sub-techniques associated to the Finding.
+	Attacks []MITREATTCKATLAS `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Findings</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -31,17 +49,32 @@ type SecurityFinding struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
-
 	// Compliance: The compliance object provides context to compliance findings (e.g., a check against a specific regulatory or best practice framework such as CIS, NIST etc.) and contains compliance related details.
 	Compliance *Compliance `json:"compliance,omitempty" parquet:"compliance,optional"`
+
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
 
 	// Data Sources: A list of data sources utilized in generation of the finding.
 	DataSources []string `json:"data_sources,omitempty" parquet:"data_sources,list,optional"`
+
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -55,6 +88,9 @@ type SecurityFinding struct {
 	// Finding: The Finding object provides details about a finding/detection generated by a security tool.
 	Finding Finding `json:"finding" parquet:"finding"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
 	// Impact: The impact , normalized to the caption of the impact_id value. In the case of 'Other', it is defined by the event source.
 	Impact *string `json:"impact,omitempty" parquet:"impact,optional"`
 
@@ -64,8 +100,17 @@ type SecurityFinding struct {
 	// Impact Score: The impact as an integer value of the finding, valid range 0-100.
 	ImpactScore *int32 `json:"impact_score,omitempty" parquet:"impact_score,optional"`
 
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
 	// Kill Chain: The <a target='_blank' href='https://www.lockheedmartin.com/en-us/capabilities/cyber/cyber-kill-chain.html'>Cyber Kill Chain®</a> provides a detailed description of each phase and its associated activities within the broader context of a cyber attack.
 	KillChain []KillChainPhase `json:"kill_chain,omitempty" parquet:"kill_chain,list,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
+	// Malware Scan Info: Describes details about the scan job that identified malware on the target system.
+	MalwareScanInfo *MalwareScanInfo `json:"malware_scan_info,omitempty" parquet:"malware_scan_info,optional"`
 
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
@@ -79,8 +124,8 @@ type SecurityFinding struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Process: The process object.
 	Process *Process `json:"process,omitempty" parquet:"process,optional"`
@@ -93,6 +138,18 @@ type SecurityFinding struct {
 
 	// Resources Array: Describes details about resources that were affected by the activity/event.
 	Resources []ResourceDetails `json:"resources,omitempty" parquet:"resources,list,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the <code>severity_id</code> value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -164,34 +221,53 @@ func (v *SecurityFinding) ValidateObservables() error {
 }
 
 var SecurityFindingFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
 	{Name: "analytic", Type: AnalyticStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKATLASStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
 	{Name: "compliance", Type: ComplianceStruct, Nullable: true},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "data_sources", Type: arrow.ListOf(arrow.BinaryTypes.String), Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
 	{Name: "finding", Type: FindingStruct, Nullable: false},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
 	{Name: "impact", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "impact_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "impact_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
 	{Name: "kill_chain", Type: arrow.ListOf(KillChainPhaseStruct), Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
+	{Name: "malware_scan_info", Type: MalwareScanInfoStruct, Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "nist", Type: arrow.ListOf(arrow.BinaryTypes.String), Nullable: true},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "process", Type: ProcessStruct, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "raw_data_size", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "resources", Type: arrow.ListOf(ResourceDetailsStruct), Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "start_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},

--- a/ocsf/v1_5_0/service_query.go
+++ b/ocsf/v1_5_0/service_query.go
@@ -10,11 +10,29 @@ import (
 
 type ServiceQuery struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
+
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® and ATLAS™ Details: An array of MITRE ATT&CK® objects describing identified tactics, techniques & sub-techniques. The objects are compatible with MITRE ATLAS™ tactics, techniques & sub-techniques.
+	Attacks []MITREATTCKATLAS `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Discovery</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -28,11 +46,26 @@ type ServiceQuery struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
+
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -43,6 +76,18 @@ type ServiceQuery struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
+	// Malware Scan Info: Describes details about the scan job that identified malware on the target system.
+	MalwareScanInfo *MalwareScanInfo `json:"malware_scan_info,omitempty" parquet:"malware_scan_info,optional"`
+
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
 
@@ -52,8 +97,8 @@ type ServiceQuery struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Query Info: The search details associated with the query request.
 	QueryInfo *QueryInformation `json:"query_info,omitempty" parquet:"query_info,optional"`
@@ -69,6 +114,18 @@ type ServiceQuery struct {
 
 	// Raw Data Size: The size of the raw data which was transformed into an OCSF event, in bytes.
 	RawDataSize *int64 `json:"raw_data_size,omitempty" parquet:"raw_data_size,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Service: The service that pertains to the event.
 	Service Service `json:"service" parquet:"service"`
@@ -134,26 +191,45 @@ func (v *ServiceQuery) ValidateObservables() error {
 }
 
 var ServiceQueryFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKATLASStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
+	{Name: "malware_scan_info", Type: MalwareScanInfoStruct, Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "query_info", Type: QueryInformationStruct, Nullable: true},
 	{Name: "query_result", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "query_result_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "raw_data_size", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "service", Type: ServiceStruct, Nullable: false},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},

--- a/ocsf/v1_5_0/session_query.go
+++ b/ocsf/v1_5_0/session_query.go
@@ -10,11 +10,29 @@ import (
 
 type UserSessionQuery struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
+
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® and ATLAS™ Details: An array of MITRE ATT&CK® objects describing identified tactics, techniques & sub-techniques. The objects are compatible with MITRE ATLAS™ tactics, techniques & sub-techniques.
+	Attacks []MITREATTCKATLAS `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Discovery</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -28,11 +46,26 @@ type UserSessionQuery struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
+
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -43,6 +76,18 @@ type UserSessionQuery struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
+	// Malware Scan Info: Describes details about the scan job that identified malware on the target system.
+	MalwareScanInfo *MalwareScanInfo `json:"malware_scan_info,omitempty" parquet:"malware_scan_info,optional"`
+
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
 
@@ -52,8 +97,8 @@ type UserSessionQuery struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Query Info: The search details associated with the query request.
 	QueryInfo *QueryInformation `json:"query_info,omitempty" parquet:"query_info,optional"`
@@ -69,6 +114,18 @@ type UserSessionQuery struct {
 
 	// Raw Data Size: The size of the raw data which was transformed into an OCSF event, in bytes.
 	RawDataSize *int64 `json:"raw_data_size,omitempty" parquet:"raw_data_size,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Session: The authenticated user or service session.
 	Session Session `json:"session" parquet:"session"`
@@ -134,26 +191,45 @@ func (v *UserSessionQuery) ValidateObservables() error {
 }
 
 var UserSessionQueryFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKATLASStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
+	{Name: "malware_scan_info", Type: MalwareScanInfoStruct, Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "query_info", Type: QueryInformationStruct, Nullable: true},
 	{Name: "query_result", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "query_result_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "raw_data_size", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "session", Type: SessionStruct, Nullable: false},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},

--- a/ocsf/v1_5_0/smb_activity.go
+++ b/ocsf/v1_5_0/smb_activity.go
@@ -10,14 +10,32 @@ import (
 
 type SMBActivity struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
 
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
 	// Application Name: The name of the application associated with the event or object.
 	AppName *string `json:"app_name,omitempty" parquet:"app_name,optional"`
+
+	// MITRE ATT&CK® and ATLAS™ Details: An array of MITRE ATT&CK® objects describing identified tactics, techniques & sub-techniques. The objects are compatible with MITRE ATLAS™ tactics, techniques & sub-techniques.
+	Attacks []MITREATTCKATLAS `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Network Activity</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -34,11 +52,17 @@ type SMBActivity struct {
 	// Client Dialects: The list of SMB dialects that the client speaks.
 	ClientDialects []string `json:"client_dialects,omitempty" parquet:"client_dialects,list,optional"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
-
 	// Command: The command name (e.g. SMB2_COMMAND_CREATE, SMB1_COMMAND_WRITE_ANDX).
 	Command *string `json:"command,omitempty" parquet:"command,optional"`
+
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Connection Info: The network connection information.
 	ConnectionInfo *NetworkConnectionInformation `json:"connection_info,omitempty" parquet:"connection_info,optional"`
@@ -49,8 +73,17 @@ type SMBActivity struct {
 	// Distributed Computing Environment/Remote Procedure Call (DCE/RPC): The DCE/RPC object describes the remote procedure call system for distributed computing environments.
 	DceRpc *DCERPC `json:"dce_rpc,omitempty" parquet:"dce_rpc,optional"`
 
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
 	// Dialect: The negotiated protocol dialect.
 	Dialect *string `json:"dialect,omitempty" parquet:"dialect,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Destination Endpoint: The responder (server) in a network connection.
 	DstEndpoint *NetworkEndpoint `json:"dst_endpoint,omitempty" parquet:"dst_endpoint,optional"`
@@ -67,8 +100,20 @@ type SMBActivity struct {
 	// File: The file that is the target of the SMB activity.
 	File *File `json:"file,omitempty" parquet:"file,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
 	// JA4+ Fingerprints: A list of the JA4+ network fingerprints.
 	Ja4FingerprintList []JA4Fingerprint `json:"ja4_fingerprint_list,omitempty" parquet:"ja4_fingerprint_list,list,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
+	// Malware Scan Info: Describes details about the scan job that identified malware on the target system.
+	MalwareScanInfo *MalwareScanInfo `json:"malware_scan_info,omitempty" parquet:"malware_scan_info,optional"`
 
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
@@ -82,8 +127,26 @@ type SMBActivity struct {
 	// Open Type: Indicates how the file was opened (e.g. normal, delete on close).
 	OpenType *string `json:"open_type,omitempty" parquet:"open_type,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
+
+	// Proxy Connection Info: The connection information from the proxy server to the remote server.
+	ProxyConnectionInfo *NetworkConnectionInformation `json:"proxy_connection_info,omitempty" parquet:"proxy_connection_info,optional"`
+
+	// Proxy Endpoint: The proxy (server) in a network connection.
+	ProxyEndpoint *NetworkProxyEndpoint `json:"proxy_endpoint,omitempty" parquet:"proxy_endpoint,optional"`
+
+	// Proxy HTTP Request: The HTTP Request from the proxy server to the remote server.
+	ProxyHttpRequest *HTTPRequest `json:"proxy_http_request,omitempty" parquet:"proxy_http_request,optional"`
+
+	// Proxy HTTP Response: The HTTP Response from the remote server to the proxy server.
+	ProxyHttpResponse *HTTPResponse `json:"proxy_http_response,omitempty" parquet:"proxy_http_response,optional"`
+
+	// Proxy TLS: The TLS protocol negotiated between the proxy server and the remote server.
+	ProxyTls *TransportLayerSecurityTLS `json:"proxy_tls,omitempty" parquet:"proxy_tls,optional"`
+
+	// Proxy Traffic: The network traffic refers to the amount of data moving across a network, from proxy to remote server at a given point of time.
+	ProxyTraffic *NetworkTraffic `json:"proxy_traffic,omitempty" parquet:"proxy_traffic,optional"`
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
@@ -93,6 +156,18 @@ type SMBActivity struct {
 
 	// API Response Details: The server response in an SMB network connection.
 	Response *ResponseElements `json:"response,omitempty" parquet:"response,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the <code>severity_id</code> value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -176,34 +251,59 @@ func (v *SMBActivity) ValidateObservables() error {
 }
 
 var SMBActivityFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
 	{Name: "app_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKATLASStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "client_dialects", Type: arrow.ListOf(arrow.BinaryTypes.String), Nullable: true},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
 	{Name: "command", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "connection_info", Type: NetworkConnectionInformationStruct, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "dce_rpc", Type: DCERPCStruct, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
 	{Name: "dialect", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "dst_endpoint", Type: NetworkEndpointStruct, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
 	{Name: "file", Type: FileStruct, Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
 	{Name: "ja4_fingerprint_list", Type: arrow.ListOf(JA4FingerprintStruct), Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
+	{Name: "malware_scan_info", Type: MalwareScanInfoStruct, Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
 	{Name: "open_type", Type: arrow.BinaryTypes.String, Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
+	{Name: "proxy_connection_info", Type: NetworkConnectionInformationStruct, Nullable: true},
+	{Name: "proxy_endpoint", Type: NetworkProxyEndpointStruct, Nullable: true},
+	{Name: "proxy_http_request", Type: HTTPRequestStruct, Nullable: true},
+	{Name: "proxy_http_response", Type: HTTPResponseStruct, Nullable: true},
+	{Name: "proxy_tls", Type: TransportLayerSecurityTLSStruct, Nullable: true},
+	{Name: "proxy_traffic", Type: NetworkTrafficStruct, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "raw_data_size", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "response", Type: ResponseElementsStruct, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "share", Type: arrow.BinaryTypes.String, Nullable: true},

--- a/ocsf/v1_5_0/software_info.go
+++ b/ocsf/v1_5_0/software_info.go
@@ -10,11 +10,29 @@ import (
 
 type SoftwareInventoryInfo struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
+
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® and ATLAS™ Details: An array of MITRE ATT&CK® objects describing identified tactics, techniques & sub-techniques. The objects are compatible with MITRE ATLAS™ tactics, techniques & sub-techniques.
+	Attacks []MITREATTCKATLAS `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Discovery</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -28,14 +46,26 @@ type SoftwareInventoryInfo struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
 
 	// Device: The device that is being discovered by an inventory process.
 	Device Device `json:"device" parquet:"device"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -46,6 +76,18 @@ type SoftwareInventoryInfo struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
+	// Malware Scan Info: Describes details about the scan job that identified malware on the target system.
+	MalwareScanInfo *MalwareScanInfo `json:"malware_scan_info,omitempty" parquet:"malware_scan_info,optional"`
+
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
 
@@ -55,8 +97,8 @@ type SoftwareInventoryInfo struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Product: Additional product attributes that have been discovered or enriched from a catalog or other external source.
 	Product *Product `json:"product,omitempty" parquet:"product,optional"`
@@ -66,6 +108,18 @@ type SoftwareInventoryInfo struct {
 
 	// Raw Data Size: The size of the raw data which was transformed into an OCSF event, in bytes.
 	RawDataSize *int64 `json:"raw_data_size,omitempty" parquet:"raw_data_size,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Software Bill Of Materials: The Software Bill of Materials (SBOM) of the device software that is being discovered by an inventory process.
 	Sbom *SoftwareBillofMaterials `json:"sbom,omitempty" parquet:"sbom,optional"`
@@ -131,25 +185,43 @@ func (v *SoftwareInventoryInfo) ValidateObservables() error {
 }
 
 var SoftwareInventoryInfoFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKATLASStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "device", Type: DeviceStruct, Nullable: false},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
+	{Name: "malware_scan_info", Type: MalwareScanInfoStruct, Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "product", Type: ProductStruct, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "raw_data_size", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "sbom", Type: SoftwareBillofMaterialsStruct, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},

--- a/ocsf/v1_5_0/ssh_activity.go
+++ b/ocsf/v1_5_0/ssh_activity.go
@@ -10,20 +10,38 @@ import (
 
 type SSHActivity struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
 
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
 	// Application Name: The name of the application associated with the event or object.
 	AppName *string `json:"app_name,omitempty" parquet:"app_name,optional"`
+
+	// MITRE ATT&CK® and ATLAS™ Details: An array of MITRE ATT&CK® objects describing identified tactics, techniques & sub-techniques. The objects are compatible with MITRE ATLAS™ tactics, techniques & sub-techniques.
+	Attacks []MITREATTCKATLAS `json:"attacks,omitempty" parquet:"attacks,list,optional"`
 
 	// Authentication Type: The SSH authentication type, normalized to the caption of 'auth_type_id'. In the case of 'Other', it is defined by the event source.
 	AuthType *string `json:"auth_type,omitempty" parquet:"auth_type,optional"`
 
 	// Authentication Type ID: The normalized identifier of the SSH authentication type.
 	AuthTypeId *int32 `json:"auth_type_id,omitempty" parquet:"auth_type_id,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Network Activity</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -40,14 +58,29 @@ type SSHActivity struct {
 	// Client HASSH: The Client HASSH fingerprinting object.
 	ClientHassh *HASSH `json:"client_hassh,omitempty" parquet:"client_hassh,optional"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Connection Info: The network connection information.
 	ConnectionInfo *NetworkConnectionInformation `json:"connection_info,omitempty" parquet:"connection_info,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
+
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Destination Endpoint: The responder (server) in a network connection.
 	DstEndpoint *NetworkEndpoint `json:"dst_endpoint,omitempty" parquet:"dst_endpoint,optional"`
@@ -64,8 +97,20 @@ type SSHActivity struct {
 	// File: The file that is the target of the SSH activity.
 	File *File `json:"file,omitempty" parquet:"file,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
 	// JA4+ Fingerprints: A list of the JA4+ network fingerprints.
 	Ja4FingerprintList []JA4Fingerprint `json:"ja4_fingerprint_list,omitempty" parquet:"ja4_fingerprint_list,list,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
+	// Malware Scan Info: Describes details about the scan job that identified malware on the target system.
+	MalwareScanInfo *MalwareScanInfo `json:"malware_scan_info,omitempty" parquet:"malware_scan_info,optional"`
 
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
@@ -76,17 +121,47 @@ type SSHActivity struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// SSH Version: The Secure Shell Protocol version.
 	ProtocolVer *string `json:"protocol_ver,omitempty" parquet:"protocol_ver,optional"`
+
+	// Proxy Connection Info: The connection information from the proxy server to the remote server.
+	ProxyConnectionInfo *NetworkConnectionInformation `json:"proxy_connection_info,omitempty" parquet:"proxy_connection_info,optional"`
+
+	// Proxy Endpoint: The proxy (server) in a network connection.
+	ProxyEndpoint *NetworkProxyEndpoint `json:"proxy_endpoint,omitempty" parquet:"proxy_endpoint,optional"`
+
+	// Proxy HTTP Request: The HTTP Request from the proxy server to the remote server.
+	ProxyHttpRequest *HTTPRequest `json:"proxy_http_request,omitempty" parquet:"proxy_http_request,optional"`
+
+	// Proxy HTTP Response: The HTTP Response from the remote server to the proxy server.
+	ProxyHttpResponse *HTTPResponse `json:"proxy_http_response,omitempty" parquet:"proxy_http_response,optional"`
+
+	// Proxy TLS: The TLS protocol negotiated between the proxy server and the remote server.
+	ProxyTls *TransportLayerSecurityTLS `json:"proxy_tls,omitempty" parquet:"proxy_tls,optional"`
+
+	// Proxy Traffic: The network traffic refers to the amount of data moving across a network, from proxy to remote server at a given point of time.
+	ProxyTraffic *NetworkTraffic `json:"proxy_traffic,omitempty" parquet:"proxy_traffic,optional"`
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
 
 	// Raw Data Size: The size of the raw data which was transformed into an OCSF event, in bytes.
 	RawDataSize *int64 `json:"raw_data_size,omitempty" parquet:"raw_data_size,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Server HASSH: The Server HASSH fingerprinting object.
 	ServerHassh *HASSH `json:"server_hassh,omitempty" parquet:"server_hassh,optional"`
@@ -161,32 +236,57 @@ func (v *SSHActivity) ValidateObservables() error {
 }
 
 var SSHActivityFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
 	{Name: "app_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKATLASStruct), Nullable: true},
 	{Name: "auth_type", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "auth_type_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "client_hassh", Type: HASSHStruct, Nullable: true},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "connection_info", Type: NetworkConnectionInformationStruct, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "dst_endpoint", Type: NetworkEndpointStruct, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
 	{Name: "file", Type: FileStruct, Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
 	{Name: "ja4_fingerprint_list", Type: arrow.ListOf(JA4FingerprintStruct), Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
+	{Name: "malware_scan_info", Type: MalwareScanInfoStruct, Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "protocol_ver", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "proxy_connection_info", Type: NetworkConnectionInformationStruct, Nullable: true},
+	{Name: "proxy_endpoint", Type: NetworkProxyEndpointStruct, Nullable: true},
+	{Name: "proxy_http_request", Type: HTTPRequestStruct, Nullable: true},
+	{Name: "proxy_http_response", Type: HTTPResponseStruct, Nullable: true},
+	{Name: "proxy_tls", Type: TransportLayerSecurityTLSStruct, Nullable: true},
+	{Name: "proxy_traffic", Type: NetworkTrafficStruct, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "raw_data_size", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "server_hassh", Type: HASSHStruct, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},

--- a/ocsf/v1_5_0/startup_item_query.go
+++ b/ocsf/v1_5_0/startup_item_query.go
@@ -10,11 +10,29 @@ import (
 
 type StartupItemQuery struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
+
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® and ATLAS™ Details: An array of MITRE ATT&CK® objects describing identified tactics, techniques & sub-techniques. The objects are compatible with MITRE ATLAS™ tactics, techniques & sub-techniques.
+	Attacks []MITREATTCKATLAS `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Discovery</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -28,11 +46,26 @@ type StartupItemQuery struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
+
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -43,6 +76,18 @@ type StartupItemQuery struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
+	// Malware Scan Info: Describes details about the scan job that identified malware on the target system.
+	MalwareScanInfo *MalwareScanInfo `json:"malware_scan_info,omitempty" parquet:"malware_scan_info,optional"`
+
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
 
@@ -52,8 +97,8 @@ type StartupItemQuery struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Query Info: The search details associated with the query request.
 	QueryInfo *QueryInformation `json:"query_info,omitempty" parquet:"query_info,optional"`
@@ -69,6 +114,18 @@ type StartupItemQuery struct {
 
 	// Raw Data Size: The size of the raw data which was transformed into an OCSF event, in bytes.
 	RawDataSize *int64 `json:"raw_data_size,omitempty" parquet:"raw_data_size,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the <code>severity_id</code> value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -134,26 +191,45 @@ func (v *StartupItemQuery) ValidateObservables() error {
 }
 
 var StartupItemQueryFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKATLASStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
+	{Name: "malware_scan_info", Type: MalwareScanInfoStruct, Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "query_info", Type: QueryInformationStruct, Nullable: true},
 	{Name: "query_result", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "query_result_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "raw_data_size", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "start_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},

--- a/ocsf/v1_5_0/tunnel_activity.go
+++ b/ocsf/v1_5_0/tunnel_activity.go
@@ -10,14 +10,32 @@ import (
 
 type TunnelActivity struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
 
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
 	// Application Name: The name of the application associated with the event or object.
 	AppName *string `json:"app_name,omitempty" parquet:"app_name,optional"`
+
+	// MITRE ATT&CK® and ATLAS™ Details: An array of MITRE ATT&CK® objects describing identified tactics, techniques & sub-techniques. The objects are compatible with MITRE ATLAS™ tactics, techniques & sub-techniques.
+	Attacks []MITREATTCKATLAS `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Network Activity</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -31,14 +49,29 @@ type TunnelActivity struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Connection Info: The tunnel connection information.
 	ConnectionInfo *NetworkConnectionInformation `json:"connection_info,omitempty" parquet:"connection_info,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
+
+	// Device: The device that reported the event.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Destination Endpoint: The server responding to the tunnel connection.
 	DstEndpoint *NetworkEndpoint `json:"dst_endpoint,omitempty" parquet:"dst_endpoint,optional"`
@@ -52,8 +85,20 @@ type TunnelActivity struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
 	// JA4+ Fingerprints: A list of the JA4+ network fingerprints.
 	Ja4FingerprintList []JA4Fingerprint `json:"ja4_fingerprint_list,omitempty" parquet:"ja4_fingerprint_list,list,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
+	// Malware Scan Info: Describes details about the scan job that identified malware on the target system.
+	MalwareScanInfo *MalwareScanInfo `json:"malware_scan_info,omitempty" parquet:"malware_scan_info,optional"`
 
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
@@ -64,17 +109,47 @@ type TunnelActivity struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Tunnel Protocol: The networking protocol associated with the tunnel. E.g. <code>IPSec</code>, <code>SSL</code>, <code>GRE</code>.
 	ProtocolName *string `json:"protocol_name,omitempty" parquet:"protocol_name,optional"`
+
+	// Proxy Connection Info: The connection information from the proxy server to the remote server.
+	ProxyConnectionInfo *NetworkConnectionInformation `json:"proxy_connection_info,omitempty" parquet:"proxy_connection_info,optional"`
+
+	// Proxy Endpoint: The proxy (server) in a network connection.
+	ProxyEndpoint *NetworkProxyEndpoint `json:"proxy_endpoint,omitempty" parquet:"proxy_endpoint,optional"`
+
+	// Proxy HTTP Request: The HTTP Request from the proxy server to the remote server.
+	ProxyHttpRequest *HTTPRequest `json:"proxy_http_request,omitempty" parquet:"proxy_http_request,optional"`
+
+	// Proxy HTTP Response: The HTTP Response from the remote server to the proxy server.
+	ProxyHttpResponse *HTTPResponse `json:"proxy_http_response,omitempty" parquet:"proxy_http_response,optional"`
+
+	// Proxy TLS: The TLS protocol negotiated between the proxy server and the remote server.
+	ProxyTls *TransportLayerSecurityTLS `json:"proxy_tls,omitempty" parquet:"proxy_tls,optional"`
+
+	// Proxy Traffic: The network traffic refers to the amount of data moving across a network, from proxy to remote server at a given point of time.
+	ProxyTraffic *NetworkTraffic `json:"proxy_traffic,omitempty" parquet:"proxy_traffic,optional"`
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
 
 	// Raw Data Size: The size of the raw data which was transformed into an OCSF event, in bytes.
 	RawDataSize *int64 `json:"raw_data_size,omitempty" parquet:"raw_data_size,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Tunnel Session: The session associated with the tunnel.
 	Session *Session `json:"session,omitempty" parquet:"session,optional"`
@@ -161,28 +236,53 @@ func (v *TunnelActivity) ValidateObservables() error {
 }
 
 var TunnelActivityFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
 	{Name: "app_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKATLASStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "connection_info", Type: NetworkConnectionInformationStruct, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "dst_endpoint", Type: NetworkEndpointStruct, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
 	{Name: "ja4_fingerprint_list", Type: arrow.ListOf(JA4FingerprintStruct), Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
+	{Name: "malware_scan_info", Type: MalwareScanInfoStruct, Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "protocol_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "proxy_connection_info", Type: NetworkConnectionInformationStruct, Nullable: true},
+	{Name: "proxy_endpoint", Type: NetworkProxyEndpointStruct, Nullable: true},
+	{Name: "proxy_http_request", Type: HTTPRequestStruct, Nullable: true},
+	{Name: "proxy_http_response", Type: HTTPResponseStruct, Nullable: true},
+	{Name: "proxy_tls", Type: TransportLayerSecurityTLSStruct, Nullable: true},
+	{Name: "proxy_traffic", Type: NetworkTrafficStruct, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "raw_data_size", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "session", Type: SessionStruct, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},

--- a/ocsf/v1_5_0/user_access.go
+++ b/ocsf/v1_5_0/user_access.go
@@ -10,11 +10,29 @@ import (
 
 type UserAccessManagement struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
+
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® and ATLAS™ Details: An array of MITRE ATT&CK® objects describing identified tactics, techniques & sub-techniques. The objects are compatible with MITRE ATLAS™ tactics, techniques & sub-techniques.
+	Attacks []MITREATTCKATLAS `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Identity & Access Management</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -28,11 +46,26 @@ type UserAccessManagement struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
+
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -43,11 +76,23 @@ type UserAccessManagement struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
 	// HTTP Request: Details about the underlying HTTP request.
 	HttpRequest *HTTPRequest `json:"http_request,omitempty" parquet:"http_request,optional"`
 
 	// HTTP Response: Details about the underlying HTTP response.
 	HttpResponse *HTTPResponse `json:"http_response,omitempty" parquet:"http_response,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
+	// Malware Scan Info: Describes details about the scan job that identified malware on the target system.
+	MalwareScanInfo *MalwareScanInfo `json:"malware_scan_info,omitempty" parquet:"malware_scan_info,optional"`
 
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
@@ -58,8 +103,8 @@ type UserAccessManagement struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Privileges: List of privileges assigned to a user.
 	Privileges []string `json:"privileges" parquet:"privileges,list"`
@@ -72,6 +117,18 @@ type UserAccessManagement struct {
 
 	// Resources Array: Resources that the privileges give access to.
 	Resources []ResourceDetails `json:"resources,omitempty" parquet:"resources,list,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the <code>severity_id</code> value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -140,27 +197,46 @@ func (v *UserAccessManagement) ValidateObservables() error {
 }
 
 var UserAccessManagementFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKATLASStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
 	{Name: "http_request", Type: HTTPRequestStruct, Nullable: true},
 	{Name: "http_response", Type: HTTPResponseStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
+	{Name: "malware_scan_info", Type: MalwareScanInfoStruct, Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "privileges", Type: arrow.ListOf(arrow.BinaryTypes.String), Nullable: false},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "raw_data_size", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "resources", Type: arrow.ListOf(ResourceDetailsStruct), Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "src_endpoint", Type: NetworkEndpointStruct, Nullable: true},

--- a/ocsf/v1_5_0/user_inventory.go
+++ b/ocsf/v1_5_0/user_inventory.go
@@ -10,11 +10,29 @@ import (
 
 type UserInventoryInfo struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
+
+	// Actor: The actor describes the process that was the source of the inventory activity. In the case of user inventory data, that could be a particular process or script that is run to scrape the user data. For example, it could be a powershell process that runs to pull data from the Azure AD graph API.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® and ATLAS™ Details: An array of MITRE ATT&CK® objects describing identified tactics, techniques & sub-techniques. The objects are compatible with MITRE ATLAS™ tactics, techniques & sub-techniques.
+	Attacks []MITREATTCKATLAS `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Discovery</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -28,11 +46,26 @@ type UserInventoryInfo struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
+
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -43,6 +76,18 @@ type UserInventoryInfo struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
+	// Malware Scan Info: Describes details about the scan job that identified malware on the target system.
+	MalwareScanInfo *MalwareScanInfo `json:"malware_scan_info,omitempty" parquet:"malware_scan_info,optional"`
+
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
 
@@ -52,14 +97,26 @@ type UserInventoryInfo struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
 
 	// Raw Data Size: The size of the raw data which was transformed into an OCSF event, in bytes.
 	RawDataSize *int64 `json:"raw_data_size,omitempty" parquet:"raw_data_size,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the <code>severity_id</code> value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -125,23 +182,42 @@ func (v *UserInventoryInfo) ValidateObservables() error {
 }
 
 var UserInventoryInfoFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKATLASStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
+	{Name: "malware_scan_info", Type: MalwareScanInfoStruct, Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "raw_data_size", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "start_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},

--- a/ocsf/v1_5_0/user_query.go
+++ b/ocsf/v1_5_0/user_query.go
@@ -10,11 +10,29 @@ import (
 
 type UserQuery struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
+
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® and ATLAS™ Details: An array of MITRE ATT&CK® objects describing identified tactics, techniques & sub-techniques. The objects are compatible with MITRE ATLAS™ tactics, techniques & sub-techniques.
+	Attacks []MITREATTCKATLAS `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Discovery</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -28,11 +46,26 @@ type UserQuery struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
+
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -43,6 +76,18 @@ type UserQuery struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
+	// Malware Scan Info: Describes details about the scan job that identified malware on the target system.
+	MalwareScanInfo *MalwareScanInfo `json:"malware_scan_info,omitempty" parquet:"malware_scan_info,optional"`
+
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
 
@@ -52,8 +97,8 @@ type UserQuery struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Query Info: The search details associated with the query request.
 	QueryInfo *QueryInformation `json:"query_info,omitempty" parquet:"query_info,optional"`
@@ -69,6 +114,18 @@ type UserQuery struct {
 
 	// Raw Data Size: The size of the raw data which was transformed into an OCSF event, in bytes.
 	RawDataSize *int64 `json:"raw_data_size,omitempty" parquet:"raw_data_size,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the <code>severity_id</code> value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -134,26 +191,45 @@ func (v *UserQuery) ValidateObservables() error {
 }
 
 var UserQueryFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKATLASStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
+	{Name: "malware_scan_info", Type: MalwareScanInfoStruct, Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "query_info", Type: QueryInformationStruct, Nullable: true},
 	{Name: "query_result", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "query_result_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "raw_data_size", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "start_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},

--- a/ocsf/v1_5_0/vulnerability_finding.go
+++ b/ocsf/v1_5_0/vulnerability_finding.go
@@ -10,11 +10,35 @@ import (
 
 type VulnerabilityFinding struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the finding activity.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The finding activity name, as defined by the <code>activity_id</code>.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
+
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// Assignee: The details of the user assigned to an Incident.
+	Assignee *User `json:"assignee,omitempty" parquet:"assignee,optional"`
+
+	// Assignee Group: The details of the group assigned to an Incident.
+	AssigneeGroup *Group `json:"assignee_group,omitempty" parquet:"assignee_group,optional"`
+
+	// MITRE ATT&CK® and ATLAS™ Details: An array of MITRE ATT&CK® objects describing identified tactics, techniques & sub-techniques. The objects are compatible with MITRE ATLAS™ tactics, techniques & sub-techniques.
+	Attacks []MITREATTCKATLAS `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Findings</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -28,14 +52,29 @@ type VulnerabilityFinding struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
-
 	// Comment: A user provided comment about the finding.
 	Comment *string `json:"comment,omitempty" parquet:"comment,optional"`
 
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
+
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
+
+	// Device: Describes the affected device/host. It can be used in conjunction with <code>Affected Resource(s)</code>. <p> e.g. Specific details about an AWS EC2 instance, that is affected by the Finding.</p>
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -49,6 +88,30 @@ type VulnerabilityFinding struct {
 	// Finding Information: Describes the supporting information about a generated finding.
 	FindingInfo FindingInformation `json:"finding_info" parquet:"finding_info"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Impact: The impact , normalized to the caption of the impact_id value. In the case of 'Other', it is defined by the event source.
+	Impact *string `json:"impact,omitempty" parquet:"impact,optional"`
+
+	// Impact ID: The normalized impact of the incident or finding. Per NIST, this is the magnitude of harm that can be expected to result from the consequences of unauthorized disclosure, modification, destruction, or loss of information or information system availability.
+	ImpactId *int32 `json:"impact_id,omitempty" parquet:"impact_id,optional"`
+
+	// Impact Score: The impact as an integer value of the finding, valid range 0-100.
+	ImpactScore *int32 `json:"impact_score,omitempty" parquet:"impact_score,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Suspected Breach: A determination based on analytics as to whether a potential breach was found.
+	IsSuspectedBreach *bool `json:"is_suspected_breach,omitempty" parquet:"is_suspected_breach,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
+	// Malware Scan Info: Describes details about the scan job that identified malware on the target system.
+	MalwareScanInfo *MalwareScanInfo `json:"malware_scan_info,omitempty" parquet:"malware_scan_info,optional"`
+
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
 
@@ -58,8 +121,14 @@ type VulnerabilityFinding struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
+
+	// Priority: The priority, normalized to the caption of the priority_id value. In the case of 'Other', it is defined by the event source.
+	Priority *string `json:"priority,omitempty" parquet:"priority,optional"`
+
+	// Priority ID: The normalized priority. Priority identifies the relative importance of the incident or finding. It is a measurement of urgency.
+	PriorityId *int32 `json:"priority_id,omitempty" parquet:"priority_id,optional"`
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
@@ -70,11 +139,26 @@ type VulnerabilityFinding struct {
 	// Affected Resources: Describes details about the resource/resources that are affected by the vulnerability/vulnerabilities.
 	Resources []ResourceDetails `json:"resources,omitempty" parquet:"resources,list,optional"`
 
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
+
 	// Severity: The event/finding severity, normalized to the caption of the <code>severity_id</code> value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
 
 	// Severity ID: <p>The normalized identifier of the event/finding severity.</p>The normalized severity is a measurement the effort and expense required to manage and resolve an event or incident. Smaller numerical values represent lower impact events, and larger numerical values represent higher impact events.
 	SeverityId int32 `json:"severity_id" parquet:"severity_id"`
+
+	// Source URL: A Url link used to access the original incident.
+	SrcUrl *string `json:"src_url,omitempty" parquet:"src_url,optional"`
 
 	// Start Time: The time of the least recent event included in the finding.
 	StartTime int64 `json:"start_time,omitempty" parquet:"start_time,timestamp_millis,timestamp(millisecond),optional"`
@@ -90,6 +174,9 @@ type VulnerabilityFinding struct {
 
 	// Status ID: The normalized status identifier of the Finding, set by the consumer.
 	StatusId *int32 `json:"status_id,omitempty" parquet:"status_id,optional"`
+
+	// Tickets: The associated ticket(s) in the ticketing system. Each ticket contains details like ticket ID, status, etc.
+	Tickets []Ticket `json:"tickets,omitempty" parquet:"tickets,list,optional"`
 
 	// Event Time: The normalized event occurrence time or the finding creation time.
 	Time int64 `json:"time" parquet:"time,timestamp_millis,timestamp(millisecond)"`
@@ -108,6 +195,12 @@ type VulnerabilityFinding struct {
 
 	// Vendor Attributes: The Vendor Attributes object can be used to represent values of attributes populated by the Vendor/Finding Provider. It can help distinguish between the vendor-prodvided values and consumer-updated values, of key attributes like <code>severity_id</code>.<br>The original finding producer should not populate this object. It should be populated by consuming systems that support data mutability.
 	VendorAttributes *VendorAttributes `json:"vendor_attributes,omitempty" parquet:"vendor_attributes,optional"`
+
+	// Verdict: The verdict assigned to an Incident finding.
+	Verdict *string `json:"verdict,omitempty" parquet:"verdict,optional"`
+
+	// Verdict ID: The normalized verdict of an Incident.
+	VerdictId *int32 `json:"verdict_id,omitempty" parquet:"verdict_id,optional"`
 
 	// Vulnerabilities: This object describes vulnerabilities reported in a security finding.
 	Vulnerabilities []VulnerabilityDetails `json:"vulnerabilities" parquet:"vulnerabilities,list"`
@@ -137,39 +230,70 @@ func (v *VulnerabilityFinding) ValidateObservables() error {
 }
 
 var VulnerabilityFindingFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "assignee", Type: UserStruct, Nullable: true},
+	{Name: "assignee_group", Type: GroupStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKATLASStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
 	{Name: "comment", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
 	{Name: "finding_info", Type: FindingInformationStruct, Nullable: false},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "impact", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "impact_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "impact_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "is_suspected_breach", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
+	{Name: "malware_scan_info", Type: MalwareScanInfoStruct, Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
+	{Name: "priority", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "priority_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "raw_data_size", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "resources", Type: arrow.ListOf(ResourceDetailsStruct), Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
+	{Name: "src_url", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "start_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "status", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "status_code", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "status_detail", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "status_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "tickets", Type: arrow.ListOf(TicketStruct), Nullable: true},
 	{Name: "time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: false},
 	{Name: "timezone_offset", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "type_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "type_uid", Type: arrow.PrimitiveTypes.Int64, Nullable: false},
 	{Name: "unmapped", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "vendor_attributes", Type: VendorAttributesStruct, Nullable: true},
+	{Name: "verdict", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "verdict_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "vulnerabilities", Type: arrow.ListOf(VulnerabilityDetailsStruct), Nullable: false},
 }
 

--- a/ocsf/v1_5_0/web_resource_access_activity.go
+++ b/ocsf/v1_5_0/web_resource_access_activity.go
@@ -10,11 +10,29 @@ import (
 
 type WebResourceAccessActivity struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
+
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® and ATLAS™ Details: An array of MITRE ATT&CK® objects describing identified tactics, techniques & sub-techniques. The objects are compatible with MITRE ATLAS™ tactics, techniques & sub-techniques.
+	Attacks []MITREATTCKATLAS `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Application Activity</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -28,11 +46,26 @@ type WebResourceAccessActivity struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
+
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -43,11 +76,23 @@ type WebResourceAccessActivity struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
 	// HTTP Request: Details about the underlying HTTP request.
 	HttpRequest HTTPRequest `json:"http_request" parquet:"http_request"`
 
 	// HTTP Response: Details about the HTTP response, if available.
 	HttpResponse *HTTPResponse `json:"http_response,omitempty" parquet:"http_response,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
+	// Malware Scan Info: Describes details about the scan job that identified malware on the target system.
+	MalwareScanInfo *MalwareScanInfo `json:"malware_scan_info,omitempty" parquet:"malware_scan_info,optional"`
 
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
@@ -58,14 +103,44 @@ type WebResourceAccessActivity struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
+
+	// Proxy Connection Info: The connection information from the proxy server to the remote server.
+	ProxyConnectionInfo *NetworkConnectionInformation `json:"proxy_connection_info,omitempty" parquet:"proxy_connection_info,optional"`
+
+	// Proxy Endpoint: The proxy (server) in a network connection.
+	ProxyEndpoint *NetworkProxyEndpoint `json:"proxy_endpoint,omitempty" parquet:"proxy_endpoint,optional"`
+
+	// Proxy HTTP Request: The HTTP Request from the proxy server to the remote server.
+	ProxyHttpRequest *HTTPRequest `json:"proxy_http_request,omitempty" parquet:"proxy_http_request,optional"`
+
+	// Proxy HTTP Response: The HTTP Response from the remote server to the proxy server.
+	ProxyHttpResponse *HTTPResponse `json:"proxy_http_response,omitempty" parquet:"proxy_http_response,optional"`
+
+	// Proxy TLS: The TLS protocol negotiated between the proxy server and the remote server.
+	ProxyTls *TransportLayerSecurityTLS `json:"proxy_tls,omitempty" parquet:"proxy_tls,optional"`
+
+	// Proxy Traffic: The network traffic refers to the amount of data moving across a network, from proxy to remote server at a given point of time.
+	ProxyTraffic *NetworkTraffic `json:"proxy_traffic,omitempty" parquet:"proxy_traffic,optional"`
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
 
 	// Raw Data Size: The size of the raw data which was transformed into an OCSF event, in bytes.
 	RawDataSize *int64 `json:"raw_data_size,omitempty" parquet:"raw_data_size,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the <code>severity_id</code> value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -137,25 +212,50 @@ func (v *WebResourceAccessActivity) ValidateObservables() error {
 }
 
 var WebResourceAccessActivityFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKATLASStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
 	{Name: "http_request", Type: HTTPRequestStruct, Nullable: false},
 	{Name: "http_response", Type: HTTPResponseStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
+	{Name: "malware_scan_info", Type: MalwareScanInfoStruct, Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
+	{Name: "proxy_connection_info", Type: NetworkConnectionInformationStruct, Nullable: true},
+	{Name: "proxy_endpoint", Type: NetworkProxyEndpointStruct, Nullable: true},
+	{Name: "proxy_http_request", Type: HTTPRequestStruct, Nullable: true},
+	{Name: "proxy_http_response", Type: HTTPResponseStruct, Nullable: true},
+	{Name: "proxy_tls", Type: TransportLayerSecurityTLSStruct, Nullable: true},
+	{Name: "proxy_traffic", Type: NetworkTrafficStruct, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "raw_data_size", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "src_endpoint", Type: NetworkEndpointStruct, Nullable: true},

--- a/ocsf/v1_5_0/web_resources_activity.go
+++ b/ocsf/v1_5_0/web_resources_activity.go
@@ -10,11 +10,29 @@ import (
 
 type WebResourcesActivity struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
 	// Activity: The event activity name, as defined by the activity_id.
 	ActivityName *string `json:"activity_name,omitempty" parquet:"activity_name,optional"`
+
+	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
+	Actor *Actor `json:"actor,omitempty" parquet:"actor,optional"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® and ATLAS™ Details: An array of MITRE ATT&CK® objects describing identified tactics, techniques & sub-techniques. The objects are compatible with MITRE ATLAS™ tactics, techniques & sub-techniques.
+	Attacks []MITREATTCKATLAS `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>Application Activity</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -28,11 +46,26 @@ type WebResourcesActivity struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
+
+	// Device: An addressable device, computer system or host.
+	Device *Device `json:"device,omitempty" parquet:"device,optional"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Destination Endpoint: Details about server providing the web resources.
 	DstEndpoint *NetworkEndpoint `json:"dst_endpoint,omitempty" parquet:"dst_endpoint,optional"`
@@ -46,11 +79,23 @@ type WebResourcesActivity struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
 	// HTTP Request: Details about the underlying HTTP request.
 	HttpRequest *HTTPRequest `json:"http_request,omitempty" parquet:"http_request,optional"`
 
 	// HTTP Response: Details about the HTTP response, if available.
 	HttpResponse *HTTPResponse `json:"http_response,omitempty" parquet:"http_response,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
+	// Malware Scan Info: Describes details about the scan job that identified malware on the target system.
+	MalwareScanInfo *MalwareScanInfo `json:"malware_scan_info,omitempty" parquet:"malware_scan_info,optional"`
 
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
@@ -61,14 +106,44 @@ type WebResourcesActivity struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
+
+	// Proxy Connection Info: The connection information from the proxy server to the remote server.
+	ProxyConnectionInfo *NetworkConnectionInformation `json:"proxy_connection_info,omitempty" parquet:"proxy_connection_info,optional"`
+
+	// Proxy Endpoint: The proxy (server) in a network connection.
+	ProxyEndpoint *NetworkProxyEndpoint `json:"proxy_endpoint,omitempty" parquet:"proxy_endpoint,optional"`
+
+	// Proxy HTTP Request: The HTTP Request from the proxy server to the remote server.
+	ProxyHttpRequest *HTTPRequest `json:"proxy_http_request,omitempty" parquet:"proxy_http_request,optional"`
+
+	// Proxy HTTP Response: The HTTP Response from the remote server to the proxy server.
+	ProxyHttpResponse *HTTPResponse `json:"proxy_http_response,omitempty" parquet:"proxy_http_response,optional"`
+
+	// Proxy TLS: The TLS protocol negotiated between the proxy server and the remote server.
+	ProxyTls *TransportLayerSecurityTLS `json:"proxy_tls,omitempty" parquet:"proxy_tls,optional"`
+
+	// Proxy Traffic: The network traffic refers to the amount of data moving across a network, from proxy to remote server at a given point of time.
+	ProxyTraffic *NetworkTraffic `json:"proxy_traffic,omitempty" parquet:"proxy_traffic,optional"`
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
 
 	// Raw Data Size: The size of the raw data which was transformed into an OCSF event, in bytes.
 	RawDataSize *int64 `json:"raw_data_size,omitempty" parquet:"raw_data_size,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the <code>severity_id</code> value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -143,26 +218,51 @@ func (v *WebResourcesActivity) ValidateObservables() error {
 }
 
 var WebResourcesActivityFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "actor", Type: ActorStruct, Nullable: true},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKATLASStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "device", Type: DeviceStruct, Nullable: true},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "dst_endpoint", Type: NetworkEndpointStruct, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
 	{Name: "http_request", Type: HTTPRequestStruct, Nullable: true},
 	{Name: "http_response", Type: HTTPResponseStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
+	{Name: "malware_scan_info", Type: MalwareScanInfoStruct, Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
+	{Name: "proxy_connection_info", Type: NetworkConnectionInformationStruct, Nullable: true},
+	{Name: "proxy_endpoint", Type: NetworkProxyEndpointStruct, Nullable: true},
+	{Name: "proxy_http_request", Type: HTTPRequestStruct, Nullable: true},
+	{Name: "proxy_http_response", Type: HTTPResponseStruct, Nullable: true},
+	{Name: "proxy_tls", Type: TransportLayerSecurityTLSStruct, Nullable: true},
+	{Name: "proxy_traffic", Type: NetworkTrafficStruct, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "raw_data_size", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "src_endpoint", Type: NetworkEndpointStruct, Nullable: true},

--- a/ocsf/v1_5_0/windows_resource_activity.go
+++ b/ocsf/v1_5_0/windows_resource_activity.go
@@ -10,6 +10,12 @@ import (
 
 type WindowsResourceActivity struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
@@ -18,6 +24,15 @@ type WindowsResourceActivity struct {
 
 	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
 	Actor Actor `json:"actor" parquet:"actor"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® and ATLAS™ Details: An array of MITRE ATT&CK® objects describing identified tactics, techniques & sub-techniques. The objects are compatible with MITRE ATLAS™ tactics, techniques & sub-techniques.
+	Attacks []MITREATTCKATLAS `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>System Activity</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -31,14 +46,26 @@ type WindowsResourceActivity struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
 
 	// Device: An addressable device, computer system or host.
 	Device Device `json:"device" parquet:"device"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -49,6 +76,18 @@ type WindowsResourceActivity struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
+	// Malware Scan Info: Describes details about the scan job that identified malware on the target system.
+	MalwareScanInfo *MalwareScanInfo `json:"malware_scan_info,omitempty" parquet:"malware_scan_info,optional"`
+
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
 
@@ -58,14 +97,26 @@ type WindowsResourceActivity struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
 
 	// Raw Data Size: The size of the raw data which was transformed into an OCSF event, in bytes.
 	RawDataSize *int64 `json:"raw_data_size,omitempty" parquet:"raw_data_size,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the <code>severity_id</code> value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -131,25 +182,42 @@ func (v *WindowsResourceActivity) ValidateObservables() error {
 }
 
 var WindowsResourceActivityFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "actor", Type: ActorStruct, Nullable: false},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKATLASStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "device", Type: DeviceStruct, Nullable: false},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
+	{Name: "malware_scan_info", Type: MalwareScanInfoStruct, Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "raw_data_size", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "start_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},

--- a/ocsf/v1_5_0/windows_service_activity.go
+++ b/ocsf/v1_5_0/windows_service_activity.go
@@ -10,6 +10,12 @@ import (
 
 type WindowsServiceActivity struct {
 
+	// Action: The normalized caption of <code>action_id</code>.
+	Action *string `json:"action,omitempty" parquet:"action,optional"`
+
+	// Action ID: The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.
+	ActionId *int32 `json:"action_id,omitempty" parquet:"action_id,optional"`
+
 	// Activity ID: The normalized identifier of the activity that triggered the event.
 	ActivityId int32 `json:"activity_id" parquet:"activity_id"`
 
@@ -18,6 +24,15 @@ type WindowsServiceActivity struct {
 
 	// Actor: The actor object describes details about the user/role/process that was the source of the activity. Note that this is not the threat actor of a campaign but may be part of a campaign.
 	Actor Actor `json:"actor" parquet:"actor"`
+
+	// API Details: Describes details about a typical API (Application Programming Interface) call.
+	Api *API `json:"api,omitempty" parquet:"api,optional"`
+
+	// MITRE ATT&CK® and ATLAS™ Details: An array of MITRE ATT&CK® objects describing identified tactics, techniques & sub-techniques. The objects are compatible with MITRE ATLAS™ tactics, techniques & sub-techniques.
+	Attacks []MITREATTCKATLAS `json:"attacks,omitempty" parquet:"attacks,list,optional"`
+
+	// Authorization Information: Provides details about an authorization, such as authorization outcome, and any associated policies related to the activity/event.
+	Authorizations []AuthorizationResult `json:"authorizations,omitempty" parquet:"authorizations,list,optional"`
 
 	// Category: The event category name, as defined by category_uid value: <code>System Activity</code>.
 	CategoryName *string `json:"category_name,omitempty" parquet:"category_name,optional"`
@@ -31,14 +46,26 @@ type WindowsServiceActivity struct {
 	// Class ID: The unique identifier of a class. A class describes the attributes available in an event.
 	ClassUid int32 `json:"class_uid" parquet:"class_uid"`
 
-	// Cloud: Describes details about the Cloud environment where the event was originally created or logged.
-	Cloud Cloud `json:"cloud" parquet:"cloud"`
+	// Confidence: The confidence, normalized to the caption of the confidence_id value. In the case of 'Other', it is defined by the event source.
+	Confidence *string `json:"confidence,omitempty" parquet:"confidence,optional"`
+
+	// Confidence ID: The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.
+	ConfidenceId *int32 `json:"confidence_id,omitempty" parquet:"confidence_id,optional"`
+
+	// Confidence Score: The confidence score as reported by the event source.
+	ConfidenceScore *int32 `json:"confidence_score,omitempty" parquet:"confidence_score,optional"`
 
 	// Count: The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.
 	Count *int32 `json:"count,omitempty" parquet:"count,optional"`
 
 	// Device: An addressable device, computer system or host.
 	Device Device `json:"device" parquet:"device"`
+
+	// Disposition: The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.
+	Disposition *string `json:"disposition,omitempty" parquet:"disposition,optional"`
+
+	// Disposition ID: Describes the outcome or action taken by a security control, such as access control checks, malware detections or various types of policy violations.
+	DispositionId *int32 `json:"disposition_id,omitempty" parquet:"disposition_id,optional"`
 
 	// Duration Milliseconds: The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.
 	Duration *int64 `json:"duration,omitempty" parquet:"duration,optional"`
@@ -49,6 +76,18 @@ type WindowsServiceActivity struct {
 	// Enrichments: The additional information from an external data source, which is associated with the event or a finding. For example add location information for the IP address in the DNS answers:</p><code>[{"name": "answers.ip", "value": "92.24.47.250", "type": "location", "data": {"city": "Socotra", "continent": "Asia", "coordinates": [-25.4153, 17.0743], "country": "YE", "desc": "Yemen"}}]</code>
 	Enrichments []Enrichment `json:"enrichments,omitempty" parquet:"enrichments,list,optional"`
 
+	// Firewall Rule: The firewall rule that pertains to the control that triggered the event, if applicable.
+	FirewallRule *FirewallRule `json:"firewall_rule,omitempty" parquet:"firewall_rule,optional"`
+
+	// Alert: Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.
+	IsAlert *bool `json:"is_alert,omitempty" parquet:"is_alert,optional"`
+
+	// Malware: A list of Malware objects, describing details about the identified malware.
+	Malware []Malware `json:"malware,omitempty" parquet:"malware,list,optional"`
+
+	// Malware Scan Info: Describes details about the scan job that identified malware on the target system.
+	MalwareScanInfo *MalwareScanInfo `json:"malware_scan_info,omitempty" parquet:"malware_scan_info,optional"`
+
 	// Message: The description of the event/finding, as defined by the source.
 	Message *string `json:"message,omitempty" parquet:"message,optional"`
 
@@ -58,14 +97,26 @@ type WindowsServiceActivity struct {
 	// Observables: The observables associated with the event or a finding.
 	Observables []Observable `json:"observables,omitempty" parquet:"observables,list,optional"`
 
-	// OSINT: The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.
-	Osint []OSINT `json:"osint" parquet:"osint,list"`
+	// Policy: The policy that pertains to the control that triggered the event, if applicable. For example the name of an anti-malware policy or an access control policy.
+	Policy *Policy `json:"policy,omitempty" parquet:"policy,optional"`
 
 	// Raw Data: The raw event/finding data as received from the source.
 	RawData *string `json:"raw_data,omitempty" parquet:"raw_data,optional"`
 
 	// Raw Data Size: The size of the raw data which was transformed into an OCSF event, in bytes.
 	RawDataSize *int64 `json:"raw_data_size,omitempty" parquet:"raw_data_size,optional"`
+
+	// Risk Details: Describes the risk associated with the finding.
+	RiskDetails *string `json:"risk_details,omitempty" parquet:"risk_details,optional"`
+
+	// Risk Level: The risk level, normalized to the caption of the risk_level_id value.
+	RiskLevel *string `json:"risk_level,omitempty" parquet:"risk_level,optional"`
+
+	// Risk Level ID: The normalized risk level id.
+	RiskLevelId *int32 `json:"risk_level_id,omitempty" parquet:"risk_level_id,optional"`
+
+	// Risk Score: The risk score as reported by the event source.
+	RiskScore *int32 `json:"risk_score,omitempty" parquet:"risk_score,optional"`
 
 	// Severity: The event/finding severity, normalized to the caption of the <code>severity_id</code> value. In the case of 'Other', it is defined by the source.
 	Severity *string `json:"severity,omitempty" parquet:"severity,optional"`
@@ -131,25 +182,42 @@ func (v *WindowsServiceActivity) ValidateObservables() error {
 }
 
 var WindowsServiceActivityFields = []arrow.Field{
+	{Name: "action", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "action_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "activity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "activity_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "actor", Type: ActorStruct, Nullable: false},
+	{Name: "api", Type: APIStruct, Nullable: true},
+	{Name: "attacks", Type: arrow.ListOf(MITREATTCKATLASStruct), Nullable: true},
+	{Name: "authorizations", Type: arrow.ListOf(AuthorizationResultStruct), Nullable: true},
 	{Name: "category_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "category_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "class_name", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "class_uid", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-	{Name: "cloud", Type: CloudStruct, Nullable: false},
+	{Name: "confidence", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "confidence_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "confidence_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "count", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "device", Type: DeviceStruct, Nullable: false},
+	{Name: "disposition", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "disposition_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "duration", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
 	{Name: "end_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},
 	{Name: "enrichments", Type: arrow.ListOf(EnrichmentStruct), Nullable: true},
+	{Name: "firewall_rule", Type: FirewallRuleStruct, Nullable: true},
+	{Name: "is_alert", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	{Name: "malware", Type: arrow.ListOf(MalwareStruct), Nullable: true},
+	{Name: "malware_scan_info", Type: MalwareScanInfoStruct, Nullable: true},
 	{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "metadata", Type: MetadataStruct, Nullable: false},
 	{Name: "observables", Type: arrow.ListOf(ObservableStruct), Nullable: true},
-	{Name: "osint", Type: arrow.ListOf(OSINTStruct), Nullable: false},
+	{Name: "policy", Type: PolicyStruct, Nullable: true},
 	{Name: "raw_data", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "raw_data_size", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+	{Name: "risk_details", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level", Type: arrow.BinaryTypes.String, Nullable: true},
+	{Name: "risk_level_id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	{Name: "risk_score", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
 	{Name: "severity", Type: arrow.BinaryTypes.String, Nullable: true},
 	{Name: "severity_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
 	{Name: "start_time", Type: arrow.FixedWidthTypes.Timestamp_ms, Nullable: true},

--- a/scripts/model_gen.go
+++ b/scripts/model_gen.go
@@ -459,21 +459,11 @@ func removeProfileFields(objects, profiles map[string]interface{}) {
 		objectProfiles := object["profiles"].([]interface{})
 		for _, objectProfileName := range objectProfiles {
 			objectProfileName := objectProfileName.(string)
-			profile := profiles[objectProfileName].(map[string]interface{})
-
 			objectAttributes := objects[objectName].(map[string]interface{})["attributes"].(map[string]interface{})
 
-			profileFields := profile["attributes"].(map[string]interface{})
-			for profileFieldName := range profileFields {
-				objectProfileAttr, ok := objectAttributes[profileFieldName]
-				if !ok || objectProfileAttr.(map[string]interface{})["requirement"] == "required" {
-					continue
-				}
-				delete(objectAttributes, profileFieldName)
-			}
+			delete(objectAttributes, objectProfileName)
 		}
 	}
-	return
 }
 
 func resolveOCSFType(targetType string, types map[string]interface{}) (string, error) {

--- a/syncers/cloudtrail/cloudtrail.go
+++ b/syncers/cloudtrail/cloudtrail.go
@@ -586,15 +586,6 @@ func (s *Syncer) ToOCSF(ctx context.Context, event CloudtrailEvent) (ocsf.APIAct
 		ClassUid:     int32(classUID),
 		Status:       &status,
 		StatusId:     int32Ptr(int32(statusID)),
-		Cloud: ocsf.Cloud{
-			Provider: "AWS",
-			Region:   stringPtr(event.AwsRegion),
-			Account: &ocsf.Account{
-				TypeId: int32Ptr(10), // AWS Account
-				Type:   stringPtr("AWS Account"),
-				Uid:    stringPtr(event.RecipientAccountID),
-			},
-		},
 
 		Resources:  resources,
 		Severity:   &severity,


### PR DESCRIPTION
This fixes a bug in the model_gen.go script that included optional profiles on generated structs.

We should think about how to include specific profiles for users that want them